### PR TITLE
Use root Evidence base path for custom domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Smoke-test Evidence
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          EVIDENCE_BASE_PATH: /fusion_issue_analysis/evidence/build
+          EVIDENCE_BASE_PATH: /evidence/build
         run: |
           uv run python3 dashboard/evidence/generate_sources.py
           cd dashboard/evidence

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Configure Evidence.dev
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          EVIDENCE_BASE_PATH: /fusion_issue_analysis/evidence/build
+          EVIDENCE_BASE_PATH: /evidence/build
         run: uv run python3 dashboard/evidence/generate_sources.py
 
       - name: Build Evidence.dev dashboard

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -72,6 +72,7 @@
   </style>
 </head>
 <body>
+  <!-- Deploy smoke test: keep dashboard/** path change behaviorless. -->
   <header>
     <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
     <nav>


### PR DESCRIPTION
Switch Evidence base path from project Pages path to site root path so custom-domain deploys work.