### PR TITLE
[codex] Fix mviz percentage normalization

### DIFF
--- a/dashboard/mviz/generate_data.py
+++ b/dashboard/mviz/generate_data.py
@@ -41,6 +41,10 @@ def write_json(filename: str, data):
     print(f"  wrote {path} ({len(data) if isinstance(data, list) else 1} records)")
 
 
+def pct0_value(value):
+    return round(value / 100, 2) if value else 0
+
+
 def main():
     os.makedirs(DATA_DIR, exist_ok=True)
     con = get_connection()
@@ -58,7 +62,7 @@ def main():
         "label": "Median Close (4wk, days)",
     })
     write_json("kpi_sla.json", {
-        "value": round(sla_pct / 100, 2) if sla_pct else 0,
+        "value": pct0_value(sla_pct),
         "label": "48h Response SLA",
         "format": "pct0",
     })
@@ -105,10 +109,10 @@ def main():
 
     # -- Triage health --
     triage = query(con, load_sql("triage"))[0]
-    write_json("kpi_triage_labeled.json", {"value": triage["pct_labeled"], "label": "% Labeled", "format": "pct0"})
-    write_json("kpi_triage_typed.json", {"value": triage["pct_typed"], "label": "% Typed", "format": "pct0"})
-    write_json("kpi_triage_assigned.json", {"value": triage["pct_assigned"], "label": "% Assigned", "format": "pct0"})
-    write_json("kpi_triage_milestoned.json", {"value": triage["pct_milestoned"], "label": "% Milestoned", "format": "pct0"})
+    write_json("kpi_triage_labeled.json", {"value": pct0_value(triage["pct_labeled"]), "label": "% Labeled", "format": "pct0"})
+    write_json("kpi_triage_typed.json", {"value": pct0_value(triage["pct_typed"]), "label": "% Typed", "format": "pct0"})
+    write_json("kpi_triage_assigned.json", {"value": pct0_value(triage["pct_assigned"]), "label": "% Assigned", "format": "pct0"})
+    write_json("kpi_triage_milestoned.json", {"value": pct0_value(triage["pct_milestoned"]), "label": "% Milestoned", "format": "pct0"})
 
     # -- Community priorities --
     write_json("community_priorities.json", query(con, "SELECT * FROM community_priorities"))

--- a/tests/test_mviz_generate_data.py
+++ b/tests/test_mviz_generate_data.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+
+from dashboard.mviz import generate_data
+
+
+class FakeConnection:
+    def close(self) -> None:
+        pass
+
+
+class MvizGenerateDataTests(unittest.TestCase):
+    def test_triage_percentage_kpis_are_normalized_for_pct_format(self) -> None:
+        writes = {}
+
+        def fake_query(_con, sql: str):
+            responses = {
+                "SELECT * FROM summary_kpis": [{
+                    "closed_4w": 10,
+                    "opened_4w": 12,
+                    "rolling_median_close_days": 4,
+                    "pct_responded_48h": 82,
+                    "open_issues": 30,
+                    "stale_count": 3,
+                }],
+                "SELECT * FROM cumulative_flow": [],
+                "SELECT * FROM bug_velocity": [],
+                "SELECT * FROM enh_velocity": [],
+                "SELECT * FROM response_pctiles": [],
+                "SELECT * FROM age_distribution": [],
+                "SELECT * FROM close_by_label": [],
+                "SELECT * FROM assignee_workload": [],
+                "triage_sql": [{
+                    "pct_labeled": 94,
+                    "pct_typed": 84,
+                    "pct_assigned": 21,
+                    "pct_milestoned": 3,
+                }],
+                "SELECT * FROM community_priorities": [],
+            }
+            return responses[sql]
+
+        def capture_write(filename: str, data):
+            writes[filename] = data
+
+        with (
+            patch.object(generate_data.os, "makedirs"),
+            patch.object(generate_data, "get_connection", return_value=FakeConnection()),
+            patch.object(generate_data, "load_sql", return_value="triage_sql"),
+            patch.object(generate_data, "query", side_effect=fake_query),
+            patch.object(generate_data, "write_json", side_effect=capture_write),
+        ):
+            generate_data.main()
+
+        self.assertEqual(writes["kpi_triage_labeled.json"]["value"], 0.94)
+        self.assertEqual(writes["kpi_triage_typed.json"]["value"], 0.84)
+        self.assertEqual(writes["kpi_triage_assigned.json"]["value"], 0.21)
+        self.assertEqual(writes["kpi_triage_milestoned.json"]["value"], 0.03)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize mviz `pct0` KPI inputs from whole-number percents to decimals in `dashboard/mviz/generate_data.py`
- reuse one helper for SLA and triage KPI exports so percent formatting stays consistent
- add regression coverage for triage KPI export values

## Root Cause
- mviz `pct0` expects decimal fractions like `0.94`, but triage KPI JSON exported whole-number percents like `94`

## Validation
- `uv run python -m unittest discover -s tests`
