### PR TITLE
Add MDV dashboard tab

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -54,6 +54,11 @@ jobs:
           uv run python generate_data.py
           npx mviz dashboard.md -o index.html
 
+      - name: Build MDV dashboard
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: bash dashboard/mdv/build.sh
+
       - name: Build ggsql dashboard
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -44,6 +44,14 @@ jobs:
           uv run python generate_data.py
           npx --yes mviz dashboard.md -o ../../preview/mviz/index.html
 
+      - name: Build MDV dashboard
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: |
+          mkdir -p preview/mdv
+          bash dashboard/mdv/build.sh
+          cp dashboard/mdv/index.html preview/mdv/index.html
+
       - name: Build ggsql dashboard
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
@@ -118,6 +126,7 @@ jobs:
               '| Prefab MySpace | `prefab/app_myspace.html` |',
               '| ggsql + Vega-Lite | `ggsql/index.html` |',
               '| mviz | `mviz/index.html` |',
+              '| MDV | `mdv/index.html` |',
               '| Observable | `observable/index.html` |',
               '| Evidence.dev | `evidence/index.html` |',
               '| Marimo | `marimo.html` |',

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,8 @@ dashboard/prefab/app.html
 dashboard/prefab/app_myspace.html
 dashboard/mviz/index.html
 dashboard/mviz/data/
+dashboard/mdv/index.html
+dashboard/mdv/data/
 dashboard/marimo.html
 dashboard/ggsql/index.html
 dashboard/__marimo__/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz marimo observable evidence quarto kill-server clean help
+.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,7 +12,7 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql mviz marimo observable evidence quarto
+build: about prefab ggsql mviz mdv marimo observable evidence quarto
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -42,6 +42,10 @@ mviz:
 	uv run python3 dashboard/mviz/generate_data.py
 	npx --yes mviz dashboard/mviz/dashboard.md -o dashboard/mviz/index.html
 
+## mdv          Generate data files and render MDV dashboard
+mdv:
+	bash dashboard/mdv/build.sh
+
 ## marimo       Export Marimo notebook to static HTML
 marimo:
 	uv run marimo export html dashboard/marimo/app.py -o dashboard/marimo.html
@@ -68,8 +72,8 @@ kill-server:
 ## clean        Remove all generated dashboard files
 clean:
 	rm -f  dashboard/prefab/app.html dashboard/prefab/app_myspace.html
-	rm -f  dashboard/ggsql/index.html dashboard/mviz/index.html dashboard/marimo.html
-	rm -rf dashboard/observable/dist dashboard/evidence/build
+	rm -f  dashboard/ggsql/index.html dashboard/mviz/index.html dashboard/mdv/index.html dashboard/marimo.html
+	rm -rf dashboard/mviz/data dashboard/mdv/data dashboard/observable/dist dashboard/evidence/build
 	rm -f  dashboard/quarto/index.html
 	rm -rf dashboard/quarto/index_files dashboard/quarto/.quarto
 

--- a/dashboard/about.html
+++ b/dashboard/about.html
@@ -108,7 +108,7 @@
 <h2>What this repo is testing</h2>
 <ul>
 <li>Same analytics problem, implemented across multiple static or static-friendly dashboard frameworks.</li>
-<li>Eight dashboard tabs sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
+<li>Nine dashboard variants sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
 <li>Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.</li>
 <li>Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.</li>
 </ul>
@@ -120,10 +120,10 @@
 <li><strong>Publish:</strong> the static wrapper ships to GitHub Pages on a custom domain.</li>
 </ol>
 <h2>Tools in the bakeoff</h2>
-<p><strong>Core bakeoff frameworks:</strong> Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, Marimo.</p>
+<p><strong>Core bakeoff frameworks:</strong> Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo.</p>
 <p><strong>Side experiments:</strong> Prefab MySpace and Quarto.</p>
 <p><strong>Data stack:</strong> dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.</p>
-<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=prefab-myspace">Prefab MySpace</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>.</p>
+<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=prefab-myspace">Prefab MySpace</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=mdv">MDV</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>.</p>
 <h2>Main challenge</h2>
 <p>Hard part is not charting. Hard part is keeping business logic out of the dashboard. Agents do this. Humans do this too. The dashboard layer always tempts you to tuck a little metric logic, filtering logic, or status logic into the page because it feels faster in the moment. But once that starts, the dashboard becomes the semantic layer by accident.</p>
 <p>The discipline here is to keep metric definitions, joins, and business rules in dbt whenever possible, then let the dashboard focus on layout, interaction, and presentation. When that boundary holds, the bakeoff is easier to compare, easier to diff, and easier to swap between tools.</p>
@@ -152,7 +152,7 @@
 <tr>
 <td>Build-time bake</td>
 <td>SQL runs in CI against MotherDuck and rows are baked into static artifacts.</td>
-<td>Prefab, Prefab MySpace, mviz, ggsql, Observable, Marimo, Quarto</td>
+<td>Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto</td>
 </tr>
 <tr>
 <td>Render-time query</td>
@@ -173,6 +173,10 @@
 <tr>
 <td>Agent-authored, spec-diffable, static</td>
 <td><a href="./?tab=mviz">mviz</a></td>
+</tr>
+<tr>
+<td>Markdown-native report with inline SVG charts</td>
+<td><a href="./?tab=mdv">MDV</a></td>
 </tr>
 <tr>
 <td>Python-first, design-system feel, KPI + charts</td>

--- a/dashboard/about.md
+++ b/dashboard/about.md
@@ -17,7 +17,7 @@ I expected a couple of options. I was surprised by how many there are. Along the
 ## What this repo is testing
 
 - Same analytics problem, implemented across multiple static or static-friendly dashboard frameworks.
-- Eight dashboard tabs sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
+- Nine dashboard variants sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
 - Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.
 - Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.
 
@@ -30,13 +30,13 @@ I expected a couple of options. I was surprised by how many there are. Along the
 
 ## Tools in the bakeoff
 
-**Core bakeoff frameworks:** Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, Marimo.
+**Core bakeoff frameworks:** Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo.
 
 **Side experiments:** Prefab MySpace and Quarto.
 
 **Data stack:** dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.
 
-**Direct links:** [Prefab](./?tab=prefab), [Prefab MySpace](./?tab=prefab-myspace), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto).
+**Direct links:** [Prefab](./?tab=prefab), [Prefab MySpace](./?tab=prefab-myspace), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [MDV](./?tab=mdv), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto).
 
 ## Main challenge
 
@@ -62,7 +62,7 @@ The interesting choices are usually in the first three. Once query engine and tr
 
 | Mode | What happens | Frameworks |
 |---|---|---|
-| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab MySpace, mviz, ggsql, Observable, Marimo, Quarto |
+| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto |
 | Render-time query | Browser reruns page SQL against shipped Parquet through DuckDB-WASM. | Evidence.dev |
 
 ## Decision guide
@@ -70,6 +70,7 @@ The interesting choices are usually in the first three. Once query engine and tr
 | If you need... | Pick |
 |---|---|
 | Agent-authored, spec-diffable, static | [mviz](./?tab=mviz) |
+| Markdown-native report with inline SVG charts | [MDV](./?tab=mdv) |
 | Python-first, design-system feel, KPI + charts | [Prefab](./?tab=prefab) |
 | SQL is the chart | [ggsql](./?tab=ggsql) |
 | Investigation more than presentation | [Marimo](./?tab=marimo) |

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -84,6 +84,7 @@
       <button data-src="prefab/app_myspace.html" data-tab="prefab-myspace" onclick="switchTab(this)">Prefab MySpace</button>
       <button data-src="ggsql/index.html" data-tab="ggsql" onclick="switchTab(this)">ggsql + Vega-Lite</button>
       <button data-src="mviz/index.html" data-tab="mviz" onclick="switchTab(this)">mviz</button>
+      <button data-src="mdv/index.html" data-tab="mdv" onclick="switchTab(this)">MDV</button>
       <button data-src="observable/dist/" data-tab="observable" onclick="switchTab(this)">Observable</button>
       <button data-src="evidence/build/" data-tab="evidence" onclick="switchTab(this)">Evidence.dev</button>
       <button data-src="marimo.html" data-tab="marimo" onclick="switchTab(this)">Marimo</button>

--- a/dashboard/mdv/build.sh
+++ b/dashboard/mdv/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MDV_SHA="${MDV_SHA:-b9d5a8c1bb66b094a8745775cb9bf1389f08403f}"
+MDV_CACHE_DIR="${MDV_CACHE_DIR:-${TMPDIR:-/tmp}/mdv-${MDV_SHA}}"
+
+export npm_config_cache="${npm_config_cache:-${TMPDIR:-/tmp}/npm-cache-mdv}"
+export PUPPETEER_SKIP_DOWNLOAD="${PUPPETEER_SKIP_DOWNLOAD:-1}"
+
+if [ ! -d "$MDV_CACHE_DIR/.git" ]; then
+  git clone https://github.com/drasimwagan/mdv.git "$MDV_CACHE_DIR"
+fi
+
+git -C "$MDV_CACHE_DIR" fetch --depth 1 origin "$MDV_SHA"
+git -C "$MDV_CACHE_DIR" checkout --detach "$MDV_SHA"
+(
+  cd "$MDV_CACHE_DIR"
+  npm install --include-workspace-root --workspaces --package-lock=false --silent
+  npm run build --workspace @mdv/core --silent
+  npm run build --workspace @mdv/cli --silent
+)
+
+uv run python3 "$HERE/generate_data.py"
+node "$MDV_CACHE_DIR/packages/mdv-cli/dist/index.js" render "$HERE/dashboard.mdv" --out "$HERE/index.html"

--- a/dashboard/mdv/dashboard.mdv
+++ b/dashboard/mdv/dashboard.mdv
@@ -1,0 +1,53 @@
+---
+title: dbt-fusion Issue Health
+theme: minimal
+data:
+  stats: ./data/stats.csv
+  velocity: ./data/velocity.csv
+  response: ./data/response.csv
+  open_by_category: ./data/open_by_category.csv
+  close_by_label: ./data/close_by_label.csv
+  community_priorities: ./data/community_priorities.csv
+styles:
+  note:
+    background: "#eef5ff"
+    border: "1px solid #b7d4ff"
+    padding: medium
+    radius: small
+---
+
+# dbt-fusion Issue Health
+
+::: note
+MDV keeps the page as Markdown with named CSV datasets. The rendered artifact is a self-contained HTML file with inline SVG charts.
+:::
+
+## Key metrics
+
+```stat data=stats
+```
+
+## Velocity
+
+```chart type=line data=velocity x=week y=days series=type points title="Median days to close"
+```
+
+## Response time
+
+```chart type=line data=response x=week y=hours series=percentile points title="Hours to first response"
+```
+
+## Open issue mix
+
+```chart type=pie data=open_by_category label=issue_category value=count donut title="Open issues by type"
+```
+
+## Slowest labels
+
+```chart type=bar data=close_by_label x=label_name y=median_days_to_close title="Median days to close by label"
+```
+
+## Community priorities
+
+```table data=community_priorities
+```

--- a/dashboard/mdv/generate_data.py
+++ b/dashboard/mdv/generate_data.py
@@ -1,0 +1,143 @@
+"""
+Generate CSV files for the MDV dashboard.
+
+MDV does not query databases directly, so this script keeps warehouse access in
+the build step and lets the .mdv file stay Markdown-native.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+DATA_DIR = HERE / "data"
+FILE_SEARCH_ROOT = Path(os.environ.get("FUSION_PROJECT_ROOT", PROJECT_ROOT))
+
+if os.environ.get("FUSION_DB"):
+    DB_PATH = os.environ["FUSION_DB"]
+elif os.environ.get("MOTHERDUCK_TOKEN"):
+    DB_PATH = "md:fusion_issues"
+else:
+    DB_PATH = str(PROJECT_ROOT / "data" / "fusion_issues.duckdb")
+
+
+def get_connection():
+    con = duckdb.connect(DB_PATH, read_only=True)
+    if not DB_PATH.startswith("md:"):
+        con.execute(f"SET file_search_path = '{FILE_SEARCH_ROOT / 'transform'}'")
+    return con
+
+
+def query(con, sql: str) -> list[dict[str, Any]]:
+    return json.loads(con.execute(sql).fetchdf().to_json(orient="records"))
+
+
+def fmt_int(value: Any) -> str:
+    return f"{int(value):,}" if value is not None else "0"
+
+
+def fmt_days(value: Any) -> str:
+    return f"{float(value):.1f}d" if value is not None else "0.0d"
+
+
+def fmt_pct(value: Any) -> str:
+    return f"{float(value):.0f}%" if value is not None else "0%"
+
+
+def build_stats(summary: dict[str, Any], triage: dict[str, Any]) -> list[dict[str, str]]:
+    net_flow = int(summary["closed_4w"]) - int(summary["opened_4w"])
+    return [
+        {"label": "Net flow (4wk)", "value": f"{net_flow:+,}", "delta": ""},
+        {"label": "Open issues", "value": fmt_int(summary["open_issues"]), "delta": ""},
+        {"label": "Median close (4wk)", "value": fmt_days(summary["rolling_median_close_days"]), "delta": ""},
+        {"label": "48h response SLA", "value": fmt_pct(summary["pct_responded_48h"]), "delta": ""},
+        {"label": "Typed open issues", "value": fmt_pct(triage["pct_typed"]), "delta": ""},
+    ]
+
+
+def write_csv(filename: str, rows: list[dict[str, Any]], fieldnames: list[str] | None = None) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    path = DATA_DIR / filename
+    columns = fieldnames or list(rows[0].keys() if rows else [])
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=columns)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"  wrote {path} ({len(rows)} records)")
+
+
+def main() -> None:
+    con = get_connection()
+
+    summary = query(con, "SELECT * FROM summary_kpis")[0]
+    triage = query(con, "SELECT * FROM triage_health")[0]
+    write_csv("stats.csv", build_stats(summary, triage), ["label", "value", "delta"])
+
+    write_csv(
+        "velocity.csv",
+        query(
+            con,
+            """
+            select week, 'Bugs' as type, median_days as days from bug_velocity
+            union all
+            select week, 'Enhancements' as type, median_days as days from enh_velocity
+            order by week, type
+            """,
+        ),
+    )
+
+    write_csv(
+        "response.csv",
+        query(
+            con,
+            """
+            select week, 'p25' as percentile, p25 as hours from response_pctiles
+            union all
+            select week, 'p50' as percentile, p50 as hours from response_pctiles
+            union all
+            select week, 'p75' as percentile, p75 as hours from response_pctiles
+            order by week, percentile
+            """,
+        ),
+    )
+
+    write_csv(
+        "open_by_category.csv",
+        query(con, "SELECT issue_category, count FROM open_by_category ORDER BY count DESC"),
+    )
+    write_csv(
+        "close_by_label.csv",
+        query(con, "SELECT label_name, median_days_to_close FROM close_by_label ORDER BY median_days_to_close DESC LIMIT 12"),
+    )
+    write_csv(
+        "community_priorities.csv",
+        query(
+            con,
+            """
+            select
+                issue_number as number,
+                title,
+                issue_category as type,
+                reactions_total_count as reactions,
+                comments_total_count as comments,
+                age_days
+            from community_priorities
+            order by reactions desc, comments desc
+            """,
+        ),
+    )
+
+    con.close()
+    print("\nDone. All data files written to mdv/data/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mdv_generate_data.py
+++ b/tests/test_mdv_generate_data.py
@@ -1,0 +1,27 @@
+import unittest
+
+from dashboard.mdv import generate_data
+
+
+class MdvGenerateDataTests(unittest.TestCase):
+    def test_build_stats_formats_dashboard_values(self) -> None:
+        rows = generate_data.build_stats(
+            {
+                "closed_4w": 17,
+                "opened_4w": 12,
+                "open_issues": 1234,
+                "rolling_median_close_days": 6.25,
+                "pct_responded_48h": 82,
+            },
+            {"pct_typed": 94},
+        )
+
+        self.assertEqual(rows[0], {"label": "Net flow (4wk)", "value": "+5", "delta": ""})
+        self.assertEqual(rows[1], {"label": "Open issues", "value": "1,234", "delta": ""})
+        self.assertEqual(rows[2], {"label": "Median close (4wk)", "value": "6.2d", "delta": ""})
+        self.assertEqual(rows[3], {"label": "48h response SLA", "value": "82%", "delta": ""})
+        self.assertEqual(rows[4], {"label": "Typed open issues", "value": "94%", "delta": ""})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an MDV tab to the dashboard wrapper
- add an MDV source page, CSV data exporter, and pinned MDV build script
- include MDV in PR preview/deploy builds and About-page links

<img width="400" alt="image" src="https://github.com/user-attachments/assets/316e2fde-d943-411e-90d7-e7d2a98f0f39" />


Closes #22.

## Dashboard Preview

Download the preview artifact from [this workflow run](https://github.com/dataders/fusion_issue_analysis/actions/runs/24890084466#artifacts) and open `index.html`.

| Framework | File |
|-----------|------|
| Prefab | `prefab/app.html` |
| Prefab MySpace | `prefab/app_myspace.html` |
| ggsql + Vega-Lite | `ggsql/index.html` |
| mviz | `mviz/index.html` |
| MDV | `mdv/index.html` |
| Observable | `observable/index.html` |
| Evidence.dev | `evidence/index.html` |
| Marimo | `marimo.html` |
| Quarto | `quarto/index.html` |
| About | `about.html` |

## Validation

- `uv run python3 dashboard/render_about.py`
- `uv run python3 -m unittest discover -s tests`
- `MDV_CACHE_DIR=/tmp/mdv-clean.tS9ukn FUSION_DB=/Users/dataders/Developer/fusion_issue_analysis/data/fusion_issues.duckdb FUSION_PROJECT_ROOT=/Users/dataders/Developer/fusion_issue_analysis bash dashboard/mdv/build.sh`
- checked generated MDV HTML for render error blocks
