### PR TITLE
[codex] Retry transient GitHub GraphQL failures

### DIFF
--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -10,6 +10,8 @@ from .settings import GRAPHQL_API_BASE_URL, REST_API_BASE_URL
 
 MAX_RETRIES = 5
 RETRY_BASE_DELAY = 30  # seconds
+RETRY_STATUS_CODES = {403, 429, 500, 502, 503, 504}
+REQUEST_TIMEOUT_SECONDS = 60
 
 
 #
@@ -133,28 +135,43 @@ def _run_graphql_query(
 ) -> Tuple[StrAny, StrAny]:
     import requests as raw_requests
 
+    retryable_errors = (
+        raw_requests.exceptions.ChunkedEncodingError,
+        raw_requests.exceptions.ConnectionError,
+        raw_requests.exceptions.Timeout,
+    )
+
+    def _sleep_before_retry(reason: str, retry_number: int) -> None:
+        delay = RETRY_BASE_DELAY * (2 ** (retry_number - 1))
+        print(
+            f"GitHub GraphQL request failed ({reason}), retrying in {delay}s "
+            f"(attempt {retry_number}/{MAX_RETRIES})"
+        )
+        time.sleep(delay)
+
     def _request() -> raw_requests.Response:
-        for attempt in range(MAX_RETRIES):
-            r = raw_requests.post(
-                GRAPHQL_API_BASE_URL,
-                json={"query": query, "variables": variables},
-                headers=_get_auth_header(access_token),
-            )
-            if r.status_code in (403, 429, 502, 503):
-                delay = RETRY_BASE_DELAY * (2 ** attempt)
-                print(f"Rate limited ({r.status_code}), retrying in {delay}s (attempt {attempt + 1}/{MAX_RETRIES})")
-                time.sleep(delay)
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                r = raw_requests.post(
+                    GRAPHQL_API_BASE_URL,
+                    json={"query": query, "variables": variables},
+                    headers=_get_auth_header(access_token),
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                )
+            except retryable_errors:
+                if attempt == MAX_RETRIES:
+                    raise
+                _sleep_before_retry("network response ended early", attempt + 1)
                 continue
+
+            if r.status_code in RETRY_STATUS_CODES and attempt < MAX_RETRIES:
+                _sleep_before_retry(f"HTTP {r.status_code}", attempt + 1)
+                continue
+
             r.raise_for_status()
             return r
-        # final attempt
-        r = raw_requests.post(
-            GRAPHQL_API_BASE_URL,
-            json={"query": query, "variables": variables},
-            headers=_get_auth_header(access_token),
-        )
-        r.raise_for_status()
-        return r
+
+        raise RuntimeError("GitHub GraphQL request retry loop exhausted")
 
     data = _request().json()
     if "errors" in data:

--- a/tests/test_github_helpers.py
+++ b/tests/test_github_helpers.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+
+import requests as raw_requests
+
+from extract.github import helpers
+
+
+class FakeGraphqlResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return {
+            "data": {
+                "repository": {"issues": {"nodes": [], "pageInfo": {"endCursor": None}}},
+                "rateLimit": {"cost": 1, "remaining": 4999},
+            }
+        }
+
+
+class GithubHelpersTests(unittest.TestCase):
+    def test_graphql_query_retries_chunked_response_failures(self) -> None:
+        with (
+            patch.object(
+                raw_requests,
+                "post",
+                side_effect=[
+                    raw_requests.exceptions.ChunkedEncodingError(
+                        "Response ended prematurely"
+                    ),
+                    FakeGraphqlResponse(),
+                ],
+            ) as post,
+            patch.object(helpers.time, "sleep") as sleep,
+        ):
+            data, rate_limit = helpers._run_graphql_query("token", "query", {})
+
+        self.assertEqual(post.call_count, 2)
+        sleep.assert_called_once()
+        self.assertEqual(rate_limit["remaining"], 4999)
+        self.assertIn("repository", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- retry transient GitHub GraphQL transport failures before dlt sees them
- add regression coverage for chunked response failures

## Root cause
GitHub GraphQL sometimes ended a chunked response prematurely, causing requests to raise ChunkedEncodingError inside extract/github/helpers.py and fail the extract job.

## Test
- uv run python3 -m unittest tests.test_github_helpers
- uv run python3 -m compileall extract tests/test_github_helpers.py

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)