### PR TITLE
[codex] Add DAC dashboard tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Install DAC
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
@@ -80,3 +85,12 @@ jobs:
         run: |
           cd dashboard/quarto
           quarto render index.qmd
+
+      - name: Smoke-test DAC
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DAC_ENVIRONMENT: prod
+          DAC_OUTPUT: /tmp/dac-build
+        run: |
+          uv run python3 dashboard/dac/render.py
+          ! grep -q 'bruin query failed' /tmp/dac-build/index.html

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Install DAC
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
@@ -103,6 +108,15 @@ jobs:
         run: |
           cd dashboard/quarto
           quarto render index.qmd
+
+      - name: Build DAC dashboard
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DAC_ENVIRONMENT: prod
+          DAC_OUTPUT: dashboard/dac/build
+        run: |
+          uv run python3 dashboard/dac/render.py
+          ! grep -q 'bruin query failed' dashboard/dac/build/index.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Install DAC
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
@@ -103,6 +108,15 @@ jobs:
           cp index.html ../../preview/quarto/index.html
           cp -r index_files ../../preview/quarto/ 2>/dev/null || true
 
+      - name: Build DAC dashboard
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          DAC_ENVIRONMENT: prod
+          DAC_OUTPUT: preview/dac
+        run: |
+          uv run python3 dashboard/dac/render.py
+          ! grep -q 'bruin query failed' preview/dac/index.html
+
       - name: Upload preview artifact
         uses: actions/upload-artifact@v4
         with:
@@ -131,6 +145,7 @@ jobs:
               '| Evidence.dev | `evidence/index.html` |',
               '| Marimo | `marimo.html` |',
               '| Quarto | `quarto/index.html` |',
+              '| DAC | `dac/index.html` |',
               '| About | `about.html` |',
               '',
               `_[Workflow run](${runUrl})_`,

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,8 @@ dashboard/evidence/.evidence/
 dashboard/quarto/.quarto/
 dashboard/quarto/index.html
 dashboard/quarto/index_files/
+dashboard/dac/build/
+logs/queries
 
 # Claude Code session state
 .claude/scheduled_tasks.lock

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto kill-server clean help
+.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto dac kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,7 +12,7 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql mviz mdv marimo observable evidence quarto
+build: about prefab ggsql mviz mdv marimo observable evidence quarto dac
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -63,6 +63,11 @@ evidence:
 quarto:
 	cd dashboard/quarto && QUARTO_PYTHON=$$(uv run which python3) quarto render index.qmd
 
+## dac          Build DAC dashboard to static HTML
+dac:
+	uv run python3 dashboard/dac/render.py
+	! grep -q 'bruin query failed' dashboard/dac/build/index.html
+
 # ── Utilities ─────────────────────────────────────────────────────────────────
 
 ## kill-server  Kill whatever is running on PORT (default: 8081)
@@ -76,6 +81,7 @@ clean:
 	rm -rf dashboard/mviz/data dashboard/mdv/data dashboard/observable/dist dashboard/evidence/build
 	rm -f  dashboard/quarto/index.html
 	rm -rf dashboard/quarto/index_files dashboard/quarto/.quarto
+	rm -rf dashboard/dac/build
 
 ## help         Show this help
 help:
@@ -86,3 +92,4 @@ help:
 	@echo "Notes:"
 	@echo "  Set MOTHERDUCK_TOKEN to build against MotherDuck instead of local DuckDB"
 	@echo "  observable and evidence require node_modules (run npm ci in each dir first)"
+	@echo "  dac requires the dac and bruin CLIs"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ What they do:
 - `make build`: export all dashboard variants
 - `make serve`: build and open local static wrapper
 
+Dashboard variants include Prefab, ggsql + Vega-Lite, mviz, MDV, Observable, Evidence.dev, Marimo, Quarto, and DAC.
+
 ## Repo Shape
 
 - `extract/`: GitHub extraction with dlt

--- a/dashboard/dac/.gitignore
+++ b/dashboard/dac/.gitignore
@@ -1,0 +1,2 @@
+bruin.yml
+!bruin.yml

--- a/dashboard/dac/bruin.yml
+++ b/dashboard/dac/bruin.yml
@@ -1,0 +1,15 @@
+default_environment: local
+
+environments:
+  local:
+    connections:
+      duckdb:
+        - name: fusion
+          path: ${FUSION_DB}
+          read_only: true
+  prod:
+    connections:
+      motherduck:
+        - name: fusion
+          token: ${MOTHERDUCK_TOKEN}
+          database: fusion_issues

--- a/dashboard/dac/dashboards/fusion-issues.yml
+++ b/dashboard/dac/dashboards/fusion-issues.yml
@@ -1,0 +1,143 @@
+name: Fusion Issue Analysis
+description: dbt-fusion GitHub issue health from the shared dbt dashboard marts.
+connection: fusion
+
+rows:
+  - widgets:
+      - name: Net Flow
+        type: metric
+        col: 3
+        sql: |
+          set file_search_path='transform';
+          select closed_4w - opened_4w as value
+          from summary_kpis
+        column: value
+        format: number
+      - name: Open Issues
+        type: metric
+        col: 3
+        sql: |
+          set file_search_path='transform';
+          select open_issues as value
+          from summary_kpis
+        column: value
+        format: number
+      - name: 48h Response SLA
+        type: metric
+        col: 3
+        sql: |
+          set file_search_path='transform';
+          select pct_responded_48h / 100.0 as value
+          from summary_kpis
+        column: value
+        format: percentage
+      - name: Stale Issues
+        type: metric
+        col: 3
+        sql: |
+          set file_search_path='transform';
+          select stale_count as value
+          from summary_kpis
+        column: value
+        format: number
+
+  - widgets:
+      - name: Cumulative Flow
+        type: chart
+        chart: line
+        col: 8
+        sql: |
+          set file_search_path='transform';
+          select
+            week,
+            cumulative_opened,
+            cumulative_closed
+          from cumulative_flow
+          order by week
+        x: week
+        y: [cumulative_opened, cumulative_closed]
+      - name: Open Issues by Category
+        type: chart
+        chart: pie
+        col: 4
+        sql: |
+          set file_search_path='transform';
+          select issue_category, count
+          from open_by_category
+          order by count desc
+        label: issue_category
+        value: count
+
+  - widgets:
+      - name: Response Time Percentiles
+        type: chart
+        chart: line
+        col: 6
+        sql: |
+          set file_search_path='transform';
+          select week, p25, p50, p75
+          from response_pctiles
+          order by week
+        x: week
+        y: [p25, p50, p75]
+      - name: Age Distribution
+        type: chart
+        chart: bar
+        stacked: true
+        col: 6
+        sql: |
+          set file_search_path='transform';
+          select
+            age_bucket,
+            sum(case when issue_category = 'bug' then issue_count else 0 end) as bug,
+            sum(case when issue_category = 'enhancement' then issue_count else 0 end) as enhancement,
+            sum(case when issue_category = 'other' then issue_count else 0 end) as other
+          from age_distribution
+          group by age_bucket
+          order by case age_bucket
+            when '0-7d' then 1
+            when '8-30d' then 2
+            when '31-90d' then 3
+            when '91-180d' then 4
+            else 5
+          end
+        x: age_bucket
+        y: [bug, enhancement, other]
+
+  - widgets:
+      - name: Oldest Open Issues
+        type: table
+        col: 12
+        sql: |
+          set file_search_path='transform';
+          select
+            issue_number,
+            title,
+            issue_category,
+            round(datediff('day', created_at, current_date), 0) as age_days,
+            reactions_total_count,
+            comments_total_count,
+            coalesce(milestone_title, '') as milestone
+          from fct_issues
+          where state = 'OPEN' and issue_category != 'epic'
+          order by created_at asc
+          limit 25
+        columns:
+          - name: issue_number
+            label: Issue
+            format: number
+          - name: title
+            label: Title
+          - name: issue_category
+            label: Type
+          - name: age_days
+            label: Age Days
+            format: number
+          - name: reactions_total_count
+            label: Reactions
+            format: number
+          - name: comments_total_count
+            label: Comments
+            format: number
+          - name: milestone
+            label: Milestone

--- a/dashboard/dac/fix_asset_paths.py
+++ b/dashboard/dac/fix_asset_paths.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+
+def fix_asset_paths(path: Path) -> None:
+    content = path.read_text()
+    content = content.replace('src="/assets/', 'src="assets/')
+    content = content.replace('href="/assets/', 'href="assets/')
+    path.write_text(content)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: fix_asset_paths.py <index.html>")
+    fix_asset_paths(Path(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/dac/render.py
+++ b/dashboard/dac/render.py
@@ -1,0 +1,57 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from fix_asset_paths import fix_asset_paths
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DAC_DIR = ROOT / "dashboard" / "dac"
+SOURCE_DASHBOARDS = DAC_DIR / "dashboards"
+CONFIG = DAC_DIR / "bruin.yml"
+PLACEHOLDER = "set file_search_path='transform';"
+DASHBOARD_NAME = "Fusion Issue Analysis"
+
+
+def render_dashboard_sources(destination: Path, transform_dir: str) -> None:
+    shutil.copytree(SOURCE_DASHBOARDS, destination)
+    dashboard = destination / "fusion-issues.yml"
+    content = dashboard.read_text()
+    dashboard.write_text(content.replace(PLACEHOLDER, f"set file_search_path='{transform_dir}';"))
+
+
+def main() -> None:
+    output = Path(os.environ.get("DAC_OUTPUT", DAC_DIR / "build"))
+    transform_dir = os.environ.get("FUSION_TRANSFORM_DIR", str(ROOT / "transform"))
+    env = os.environ.copy()
+    env.setdefault("FUSION_DB", "../../data/fusion_issues.duckdb")
+    env_name = env.get("DAC_ENVIRONMENT")
+
+    with tempfile.TemporaryDirectory(prefix="fusion-dac-") as tmp:
+        tmp_path = Path(tmp)
+        dashboards = tmp_path / "dashboards"
+        render_dashboard_sources(dashboards, transform_dir)
+        config = CONFIG
+        if env_name:
+            config = tmp_path / "bruin.yml"
+            config.write_text(CONFIG.read_text().replace("default_environment: local", f"default_environment: {env_name}"))
+
+        command = ["dac", "--config", str(config)]
+        command.extend([
+            "build",
+            "--dir",
+            str(tmp_path),
+            "--dashboard",
+            DASHBOARD_NAME,
+            "--output",
+            str(output),
+        ])
+        subprocess.run(command, check=True, env=env)
+
+    fix_asset_paths(output / "index.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -89,6 +89,7 @@
       <button data-src="evidence/build/" data-tab="evidence" onclick="switchTab(this)">Evidence.dev</button>
       <button data-src="marimo.html" data-tab="marimo" onclick="switchTab(this)">Marimo</button>
       <button data-src="quarto/index.html" data-tab="quarto" onclick="switchTab(this)">Quarto</button>
+      <button data-src="dac/build/" data-tab="dac" onclick="switchTab(this)">DAC</button>
       <button data-src="about.html" data-tab="about" onclick="switchTab(this)">About</button>
     </nav>
   </header>

--- a/tests/test_dac_dashboard.py
+++ b/tests/test_dac_dashboard.py
@@ -1,0 +1,81 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_HTML = REPO_ROOT / "dashboard" / "index.html"
+MAKEFILE = REPO_ROOT / "Makefile"
+PR_PREVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-preview.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dashboard.yml"
+DAC_CONFIG = REPO_ROOT / "dashboard" / "dac" / "bruin.yml"
+DAC_DASHBOARD = REPO_ROOT / "dashboard" / "dac" / "dashboards" / "fusion-issues.yml"
+DAC_ASSET_FIX = REPO_ROOT / "dashboard" / "dac" / "fix_asset_paths.py"
+DAC_RENDER = REPO_ROOT / "dashboard" / "dac" / "render.py"
+
+
+class DacDashboardTests(unittest.TestCase):
+    def test_bakeoff_tab_points_to_dac_static_build(self) -> None:
+        content = INDEX_HTML.read_text()
+        self.assertIn("DAC", content)
+        self.assertIn('data-src="dac/build/"', content)
+
+    def test_makefile_builds_and_cleans_dac(self) -> None:
+        content = MAKEFILE.read_text()
+        self.assertIn("build: about prefab ggsql mviz mdv marimo observable evidence quarto dac", content)
+        self.assertIn("uv run python3 dashboard/dac/render.py", content)
+        self.assertIn("dashboard/dac/build", content)
+
+    def test_ci_and_preview_workflows_build_dac(self) -> None:
+        preview = PR_PREVIEW_WORKFLOW.read_text()
+        ci = CI_WORKFLOW.read_text()
+        deploy = DEPLOY_WORKFLOW.read_text()
+
+        for content in (preview, ci, deploy):
+            self.assertIn("Install DAC", content)
+            self.assertIn("DAC_ENVIRONMENT: prod", content)
+            self.assertIn("uv run python3 dashboard/dac/render.py", content)
+
+        self.assertIn("preview/dac", preview)
+        self.assertIn("| DAC | `dac/index.html` |", preview)
+        self.assertIn("dashboard/dac/build", deploy)
+
+    def test_dac_project_uses_fusion_issue_marts(self) -> None:
+        config = DAC_CONFIG.read_text()
+        dashboard = DAC_DASHBOARD.read_text()
+
+        self.assertIn("path: ${FUSION_DB}", config)
+        self.assertIn("motherduck:", config)
+        self.assertIn("token: ${MOTHERDUCK_TOKEN}", config)
+        self.assertIn("database: fusion_issues", config)
+        self.assertIn('env.setdefault("FUSION_DB", "../../data/fusion_issues.duckdb")', DAC_RENDER.read_text())
+        self.assertIn("name: Fusion Issue Analysis", dashboard)
+        self.assertIn("connection: fusion", dashboard)
+        self.assertIn("from fct_issues", dashboard)
+        self.assertIn("cumulative_flow", dashboard)
+        self.assertIn("open_issues", dashboard)
+        self.assertIn("FUSION_TRANSFORM_DIR", DAC_RENDER.read_text())
+        self.assertIn("default_environment: {env_name}", DAC_RENDER.read_text())
+
+    def test_dac_asset_rewrite_makes_nested_static_build_portable(self) -> None:
+        spec = importlib.util.spec_from_file_location("fix_asset_paths", DAC_ASSET_FIX)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "index.html"
+            path.write_text('<script src="/assets/app.js"></script><link href="/assets/app.css">')
+            module.fix_asset_paths(path)
+
+            rewritten = path.read_text()
+            self.assertIn('src="assets/app.js"', rewritten)
+            self.assertIn('href="assets/app.css"', rewritten)
+            self.assertNotIn('"/assets/', rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add DAC as a dashboard bakeoff tab.
- Add a DAC Bruin dashboard backed by the shared issue marts.
- Wire DAC into CI, PR preview artifacts, deploy, Makefile, and regression tests.

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

CI also uploads `dashboard-preview`; open `index.html` and use `dac/index.html` for the DAC page.

## Validation

- `uv run python3 -m unittest tests.test_dac_dashboard`
- `PATH=/tmp/dac-bin:$PATH TELEMETRY_OPTOUT=1 make dac`
- `uv run python3 -m unittest discover -s tests`
- `git diff --check`
