### PR TITLE
[codex] Fix DAC deploy output

### DIFF
--- a/dashboard/dac/render.py
+++ b/dashboard/dac/render.py
@@ -13,6 +13,11 @@ SOURCE_DASHBOARDS = DAC_DIR / "dashboards"
 CONFIG = DAC_DIR / "bruin.yml"
 PLACEHOLDER = "set file_search_path='transform';"
 DASHBOARD_NAME = "Fusion Issue Analysis"
+ERROR_MARKERS = (
+    "bruin query failed",
+    "parsing bruin query output",
+    "Installing uv ",
+)
 
 
 def render_dashboard_sources(destination: Path, transform_dir: str) -> None:
@@ -20,6 +25,31 @@ def render_dashboard_sources(destination: Path, transform_dir: str) -> None:
     dashboard = destination / "fusion-issues.yml"
     content = dashboard.read_text()
     dashboard.write_text(content.replace(PLACEHOLDER, f"set file_search_path='{transform_dir}';"))
+
+
+def warm_bruin_query_runtime(config: Path, env: dict[str, str], env_name: str) -> None:
+    command = [
+        "bruin",
+        "query",
+        "--config-file",
+        str(config),
+        "--environment",
+        env_name,
+        "--connection",
+        "fusion",
+        "--query",
+        "select 1 as value",
+        "--output",
+        "json",
+    ]
+    subprocess.run(command, check=True, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+
+def validate_static_output(path: Path) -> None:
+    content = path.read_text()
+    matches = [marker for marker in ERROR_MARKERS if marker in content]
+    if matches:
+        raise SystemExit(f"DAC static build contains query errors: {', '.join(matches)}")
 
 
 def main() -> None:
@@ -37,6 +67,7 @@ def main() -> None:
         if env_name:
             config = tmp_path / "bruin.yml"
             config.write_text(CONFIG.read_text().replace("default_environment: local", f"default_environment: {env_name}"))
+            warm_bruin_query_runtime(config, env, env_name)
 
         command = ["dac", "--config", str(config)]
         command.extend([
@@ -51,6 +82,7 @@ def main() -> None:
         subprocess.run(command, check=True, env=env)
 
     fix_asset_paths(output / "index.html")
+    validate_static_output(output / "index.html")
 
 
 if __name__ == "__main__":

--- a/tests/test_dac_dashboard.py
+++ b/tests/test_dac_dashboard.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -58,12 +59,14 @@ class DacDashboardTests(unittest.TestCase):
         self.assertIn("open_issues", dashboard)
         self.assertIn("FUSION_TRANSFORM_DIR", DAC_RENDER.read_text())
         self.assertIn("default_environment: {env_name}", DAC_RENDER.read_text())
+        self.assertIn("warm_bruin_query_runtime(config, env, env_name)", DAC_RENDER.read_text())
 
     def test_dac_asset_rewrite_makes_nested_static_build_portable(self) -> None:
         spec = importlib.util.spec_from_file_location("fix_asset_paths", DAC_ASSET_FIX)
         self.assertIsNotNone(spec)
         module = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
+        sys.path.insert(0, str(DAC_RENDER.parent))
         spec.loader.exec_module(module)
 
         with TemporaryDirectory() as tmpdir:
@@ -75,6 +78,20 @@ class DacDashboardTests(unittest.TestCase):
             self.assertIn('src="assets/app.js"', rewritten)
             self.assertIn('href="assets/app.css"', rewritten)
             self.assertNotIn('"/assets/', rewritten)
+
+    def test_dac_static_output_validation_rejects_baked_query_errors(self) -> None:
+        spec = importlib.util.spec_from_file_location("render", DAC_RENDER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "index.html"
+            path.write_text("parsing bruin query output: Installing uv v0.10.8")
+
+            with self.assertRaises(SystemExit):
+                module.validate_static_output(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Warm Bruin's query runtime before DAC static export in prod builds.
- Fail DAC export if static HTML contains baked query/parser errors.
- Add regression coverage for the exact deployed failure mode.

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

CI also uploads `dashboard-preview`; open `index.html` and use `dac/index.html` for the DAC page.

## Validation

- `uv run python3 -m unittest tests.test_dac_dashboard`
- `PATH=/tmp/dac-bin:$PATH TELEMETRY_OPTOUT=1 make dac`
- `uv run python3 -m unittest discover -s tests`
- `git diff --check`
