### PR TITLE
Pin mviz 1.6.7 for sortable tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd dashboard/mviz
           uv run python generate_data.py
-          npx --yes mviz dashboard.md -o /tmp/mviz.html
+          npx --yes mviz@1.6.7 dashboard.md -o /tmp/mviz.html
 
       - name: Smoke-test ggsql
         env:

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           cd dashboard/mviz
           uv run python generate_data.py
-          npx mviz dashboard.md -o index.html
+          npx --yes mviz@1.6.7 dashboard.md -o index.html
 
       - name: Build MDV dashboard
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p preview/mviz
           cd dashboard/mviz
           uv run python generate_data.py
-          npx --yes mviz dashboard.md -o ../../preview/mviz/index.html
+          npx --yes mviz@1.6.7 dashboard.md -o ../../preview/mviz/index.html
 
       - name: Build MDV dashboard
         env:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ggsql:
 ## mviz         Generate data files and render mviz dashboard
 mviz:
 	uv run python3 dashboard/mviz/generate_data.py
-	npx --yes mviz dashboard/mviz/dashboard.md -o dashboard/mviz/index.html
+	npx --yes mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html
 
 ## mdv          Generate data files and render MDV dashboard
 mdv:

--- a/dashboard/mviz/build.sh
+++ b/dashboard/mviz/build.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Build the mviz dashboard: generate data then render HTML.
-# Usage: bash dashboard/build_mviz.sh
+# Usage: bash dashboard/mviz/build.sh
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../.."
 
 echo "==> Generating data files..."
-uv run python dashboard/generate_data.py
+uv run python3 dashboard/mviz/generate_data.py
 
 echo "==> Rendering mviz dashboard..."
-npx mviz dashboard/mviz_dashboard.md -o dashboard/mviz.html
+npx --yes mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html
 
-echo "==> Done: dashboard/mviz.html"
+echo "==> Done: dashboard/mviz/index.html"


### PR DESCRIPTION
## Summary
- Pin mviz CLI invocations to `mviz@1.6.7` so generated tables include sortable headers.
- Refresh the legacy mviz build script to use the current dashboard paths.

Closes #27

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

## Tests
- `make mviz`
- `bash dashboard/mviz/build.sh`
- `uv run python3 -m unittest tests.test_mviz_generate_data`
