### PR TITLE
Gate uv dependency updates by publish age

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "pyyaml>=6.0.3",
 ]
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [dependency-groups]
 dev = [
     "jupyter>=1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,10 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-22T17:54:56.303702Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "agate"
 version = "1.9.1"


### PR DESCRIPTION
## Summary
- Add `tool.uv.exclude-newer = "1 week"` so uv avoids packages published in the last week during resolution.
- Refresh `uv.lock` so the age gate is recorded in lock metadata.

## Tests
- `uv lock --check`
- `uv sync --locked --dev`
