### PR TITLE
Add Shaper to dashboard bakeoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
+      - name: Build Shaper tab
+        run: uv run python3 dashboard/shaper/build.py
+
       # ── Dashboard smoke-test (all frameworks, no || true) ─────────────────
       # Data comes from MotherDuck — extract.yml keeps it fresh 4x/day.
       # No extract or dbt build here; those run in extract.yml on schedule

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
+      - name: Build Shaper tab
+        run: uv run python3 dashboard/shaper/build.py
+
       - name: Export Prefab dashboards
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 
+      - name: Build Shaper tab
+        run: uv run python3 dashboard/shaper/build.py
+
       # Data comes from MotherDuck — no extract or dbt build needed.
 
       - name: Export Prefab dashboards
@@ -37,6 +40,10 @@ jobs:
           mkdir -p preview/prefab
           cp dashboard/index.html preview/index.html
           cp dashboard/about.html preview/about.html
+          mkdir -p preview/shaper
+          cp dashboard/shaper/index.html preview/shaper/index.html
+          cp dashboard/shaper/fusion-issue-health.dashboard.sql preview/shaper/fusion-issue-health.dashboard.sql
+          cp dashboard/shaper/shaper.json preview/shaper/shaper.json
           uv run prefab export dashboard/prefab/app.py -o preview/prefab/app.html
           uv run prefab export dashboard/prefab/app_myspace.py -o preview/prefab/app_myspace.html
 
@@ -146,6 +153,7 @@ jobs:
               '| Marimo | `marimo.html` |',
               '| Quarto | `quarto/index.html` |',
               '| DAC | `dac/index.html` |',
+              '| Shaper | `shaper/index.html` |',
               '| About | `about.html` |',
               '',
               `_[Workflow run](${runUrl})_`,

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto dac kill-server clean help
+.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto dac shaper kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,7 +12,7 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql mviz mdv marimo observable evidence quarto dac
+build: about prefab ggsql mviz mdv marimo observable evidence quarto dac shaper
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -67,6 +67,10 @@ quarto:
 dac:
 	uv run python3 dashboard/dac/render.py
 	! grep -q 'bruin query failed' dashboard/dac/build/index.html
+
+## shaper       Build Shaper source-preview tab
+shaper:
+	uv run python3 dashboard/shaper/build.py
 
 # ── Utilities ─────────────────────────────────────────────────────────────────
 

--- a/dashboard/about.html
+++ b/dashboard/about.html
@@ -107,8 +107,8 @@
 <p>I expected a couple of options. I was surprised by how many there are. Along the way I started to learn what the static dashboard stack actually looks like, where it is strong, where it gets awkward, and how to make it work cleanly with dbt.</p>
 <h2>What this repo is testing</h2>
 <ul>
-<li>Same analytics problem, implemented across multiple static or static-friendly dashboard frameworks.</li>
-<li>Nine dashboard variants sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
+<li>Same analytics problem, implemented across multiple static, static-friendly, and server-backed dashboard frameworks.</li>
+<li>Eleven dashboard variants sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
 <li>Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.</li>
 <li>Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.</li>
 </ul>
@@ -120,10 +120,10 @@
 <li><strong>Publish:</strong> the static wrapper ships to GitHub Pages on a custom domain.</li>
 </ol>
 <h2>Tools in the bakeoff</h2>
-<p><strong>Core bakeoff frameworks:</strong> Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo.</p>
+<p><strong>Core bakeoff frameworks:</strong> Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo, DAC, Shaper.</p>
 <p><strong>Side experiments:</strong> Prefab MySpace and Quarto.</p>
 <p><strong>Data stack:</strong> dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.</p>
-<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=prefab-myspace">Prefab MySpace</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=mdv">MDV</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>.</p>
+<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=prefab-myspace">Prefab MySpace</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=mdv">MDV</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>, <a href="./?tab=dac">DAC</a>, <a href="./?tab=shaper">Shaper</a>.</p>
 <h2>Main challenge</h2>
 <p>Hard part is not charting. Hard part is keeping business logic out of the dashboard. Agents do this. Humans do this too. The dashboard layer always tempts you to tuck a little metric logic, filtering logic, or status logic into the page because it feels faster in the moment. But once that starts, the dashboard becomes the semantic layer by accident.</p>
 <p>The discipline here is to keep metric definitions, joins, and business rules in dbt whenever possible, then let the dashboard focus on layout, interaction, and presentation. When that boundary holds, the bakeoff is easier to compare, easier to diff, and easier to swap between tools.</p>
@@ -152,12 +152,17 @@
 <tr>
 <td>Build-time bake</td>
 <td>SQL runs in CI against MotherDuck and rows are baked into static artifacts.</td>
-<td>Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto</td>
+<td>Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC</td>
 </tr>
 <tr>
 <td>Render-time query</td>
 <td>Browser reruns page SQL against shipped Parquet through DuckDB-WASM.</td>
 <td>Evidence.dev</td>
+</tr>
+<tr>
+<td>Server-backed runtime</td>
+<td>SQL lives in Git, but rendering expects a live app server rather than a GitHub Pages bundle.</td>
+<td>Shaper</td>
 </tr>
 </tbody>
 </table>
@@ -202,6 +207,10 @@
 <td>Narrative report or document feel</td>
 <td><a href="./?tab=quarto">Quarto</a></td>
 </tr>
+<tr>
+<td>SQL-first product dashboard with sharing, embeds, and reports if a server is acceptable</td>
+<td><a href="./?tab=shaper">Shaper</a></td>
+</tr>
 </tbody>
 </table>
 <h2>Open questions</h2>
@@ -211,6 +220,7 @@
 <li>Should Evidence push all the way to true browser-to-MotherDuck querying, or is baked static data the better constraint?</li>
 <li>What is the best authoring format for agents: JSON specs, SQL-first tools, Markdown + SQL, or Python?</li>
 <li>How interactive can a static dashboard get before it becomes an accidental app?</li>
+<li>Which server-backed tools belong in the comparison even if GitHub Pages can only ship their source preview?</li>
 <li>What is the right preview target for this kind of project: GitHub Pages, Netlify-style previews, or something more data-tool-native?</li>
 </ul>
   </main>

--- a/dashboard/about.md
+++ b/dashboard/about.md
@@ -16,8 +16,8 @@ I expected a couple of options. I was surprised by how many there are. Along the
 
 ## What this repo is testing
 
-- Same analytics problem, implemented across multiple static or static-friendly dashboard frameworks.
-- Nine dashboard variants sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
+- Same analytics problem, implemented across multiple static, static-friendly, and server-backed dashboard frameworks.
+- Eleven dashboard variants sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
 - Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.
 - Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.
 
@@ -30,13 +30,13 @@ I expected a couple of options. I was surprised by how many there are. Along the
 
 ## Tools in the bakeoff
 
-**Core bakeoff frameworks:** Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo.
+**Core bakeoff frameworks:** Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo, DAC, Shaper.
 
 **Side experiments:** Prefab MySpace and Quarto.
 
 **Data stack:** dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.
 
-**Direct links:** [Prefab](./?tab=prefab), [Prefab MySpace](./?tab=prefab-myspace), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [MDV](./?tab=mdv), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto).
+**Direct links:** [Prefab](./?tab=prefab), [Prefab MySpace](./?tab=prefab-myspace), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [MDV](./?tab=mdv), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto), [DAC](./?tab=dac), [Shaper](./?tab=shaper).
 
 ## Main challenge
 
@@ -62,8 +62,9 @@ The interesting choices are usually in the first three. Once query engine and tr
 
 | Mode | What happens | Frameworks |
 |---|---|---|
-| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto |
+| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC |
 | Render-time query | Browser reruns page SQL against shipped Parquet through DuckDB-WASM. | Evidence.dev |
+| Server-backed runtime | SQL lives in Git, but rendering expects a live app server rather than a GitHub Pages bundle. | Shaper |
 
 ## Decision guide
 
@@ -77,6 +78,7 @@ The interesting choices are usually in the first three. Once query engine and tr
 | Analyst-authored BI site with filters and polish | [Evidence.dev](./?tab=evidence) |
 | Rich interactivity + bespoke viz if you accept Node | [Observable Framework](./?tab=observable) |
 | Narrative report or document feel | [Quarto](./?tab=quarto) |
+| SQL-first product dashboard with sharing, embeds, and reports if a server is acceptable | [Shaper](./?tab=shaper) |
 
 ## Open questions
 
@@ -85,4 +87,5 @@ The interesting choices are usually in the first three. Once query engine and tr
 - Should Evidence push all the way to true browser-to-MotherDuck querying, or is baked static data the better constraint?
 - What is the best authoring format for agents: JSON specs, SQL-first tools, Markdown + SQL, or Python?
 - How interactive can a static dashboard get before it becomes an accidental app?
+- Which server-backed tools belong in the comparison even if GitHub Pages can only ship their source preview?
 - What is the right preview target for this kind of project: GitHub Pages, Netlify-style previews, or something more data-tool-native?

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -90,6 +90,7 @@
       <button data-src="marimo.html" data-tab="marimo" onclick="switchTab(this)">Marimo</button>
       <button data-src="quarto/index.html" data-tab="quarto" onclick="switchTab(this)">Quarto</button>
       <button data-src="dac/build/" data-tab="dac" onclick="switchTab(this)">DAC</button>
+      <button data-src="shaper/index.html" data-tab="shaper" onclick="switchTab(this)">Shaper</button>
       <button data-src="about.html" data-tab="about" onclick="switchTab(this)">About</button>
     </nav>
   </header>

--- a/dashboard/shaper/build.py
+++ b/dashboard/shaper/build.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+import re
+
+
+HERE = Path(__file__).resolve().parent
+SOURCE = HERE / "fusion-issue-health.dashboard.sql"
+CONFIG = HERE / "shaper.json"
+TARGET = HERE / "index.html"
+DOCS_URL = "https://taleshape.com/shaper/docs/"
+REPO_URL = "https://github.com/taleshape-com/shaper"
+SCREENSHOT_URL = "https://taleshape.com/images/session_dashboard.png"
+SHAPER_ID_RE = re.compile(r"^-- shaperid:[^\s]+$", re.MULTILINE)
+
+
+def load_source() -> str:
+    sql = SOURCE.read_text()
+    if not SHAPER_ID_RE.search(sql):
+        raise SystemExit(f"{SOURCE} is missing leading -- shaperid comment")
+    return sql
+
+
+def statement_count(sql: str) -> int:
+    return sum(1 for part in sql.split(";") if part.strip())
+
+
+def render_page(sql: str) -> str:
+    escaped_sql = escape(sql.strip())
+    statements = statement_count(sql)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shaper | dbt-fusion Issue Analysis</title>
+  <style>
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #202124;
+      background: #f6f7fb;
+    }}
+    main {{
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 34px 20px 56px;
+    }}
+    header {{
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+      gap: 28px;
+      align-items: center;
+      margin-bottom: 28px;
+    }}
+    header > *,
+    .body-grid > * {{
+      min-width: 0;
+    }}
+    h1 {{
+      margin: 0 0 10px;
+      font-size: clamp(2.2rem, 5vw, 4rem);
+      line-height: 1;
+      letter-spacing: 0;
+    }}
+    h2 {{
+      margin: 0 0 12px;
+      font-size: 1.05rem;
+    }}
+    p {{
+      margin: 0;
+      line-height: 1.55;
+      color: #3f4550;
+    }}
+    a {{ color: #145ea8; }}
+    .eyebrow {{
+      margin-bottom: 10px;
+      color: #6b4b12;
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }}
+    .hero-text {{
+      font-size: 1.08rem;
+      max-width: 680px;
+    }}
+    .hero-image {{
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
+      border: 1px solid #d8dde7;
+      border-radius: 8px;
+      background: #fff;
+      box-shadow: 0 18px 44px rgba(33, 41, 54, 0.14);
+    }}
+    .actions {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }}
+    .actions a {{
+      display: inline-flex;
+      min-height: 38px;
+      align-items: center;
+      padding: 0 13px;
+      border: 1px solid #b8c4d8;
+      border-radius: 6px;
+      background: #fff;
+      color: #173c66;
+      font-weight: 650;
+      text-decoration: none;
+    }}
+    .panel {{
+      min-width: 0;
+      border: 1px solid #d8dde7;
+      border-radius: 8px;
+      background: #fff;
+      padding: 18px;
+      box-shadow: 0 8px 24px rgba(33, 41, 54, 0.07);
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
+    }}
+    .metric {{
+      min-width: 0;
+      min-height: 96px;
+      border: 1px solid #dce2ec;
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcff;
+    }}
+    .metric strong {{
+      display: block;
+      margin-bottom: 7px;
+      font-size: 1.05rem;
+    }}
+    .metric span {{
+      display: block;
+      color: #667085;
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }}
+    .body-grid {{
+      display: grid;
+      grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
+      gap: 16px;
+      align-items: start;
+    }}
+    ul {{
+      margin: 0;
+      padding-left: 18px;
+      color: #3f4550;
+      line-height: 1.55;
+    }}
+    code {{
+      padding: 0.08rem 0.28rem;
+      border-radius: 4px;
+      background: #eef3ff;
+      font-size: 0.93em;
+    }}
+    pre {{
+      max-width: 100%;
+      max-height: 620px;
+      margin: 0;
+      overflow: auto;
+      border-radius: 6px;
+      background: #111827;
+      color: #e9edf7;
+      padding: 16px;
+      font-size: 0.86rem;
+      line-height: 1.45;
+      white-space: pre;
+    }}
+    .small {{
+      color: #667085;
+      font-size: 0.9rem;
+    }}
+    @media (max-width: 1050px) {{
+      header,
+      .body-grid {{
+        grid-template-columns: 1fr;
+      }}
+      .grid {{
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }}
+    }}
+    @media (max-width: 640px) {{
+      header,
+      .body-grid,
+      .grid {{
+        grid-template-columns: 1fr;
+      }}
+      main {{
+        padding: 24px 14px 40px;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <div class="eyebrow">Server-backed SQL dashboard</div>
+        <h1>Shaper</h1>
+        <p class="hero-text">Open source Shaper joins the bakeoff as a SQL-first DuckDB dashboard. This tab ships the tracked <code>.dashboard.sql</code> source and makes the GitHub Pages limitation explicit: Shaper renders from a live Shaper server, not a static export bundle.</p>
+        <div class="actions">
+          <a href="fusion-issue-health.dashboard.sql">Dashboard SQL</a>
+          <a href="shaper.json">shaper.json</a>
+          <a href="{DOCS_URL}" target="_blank" rel="noreferrer">Docs</a>
+          <a href="{REPO_URL}" target="_blank" rel="noreferrer">Source</a>
+        </div>
+      </div>
+      <img class="hero-image" src="{SCREENSHOT_URL}" alt="Shaper dashboard screenshot">
+    </header>
+
+    <section class="grid" aria-label="Shaper tab facts">
+      <div class="metric"><strong>{statements}</strong><span>SQL statements in the tracked Shaper dashboard file.</span></div>
+      <div class="metric"><strong>DuckDB</strong><span>Runtime engine expected by Shaper and this repo.</span></div>
+      <div class="metric"><strong>dbt marts</strong><span>Queries stay on shared dashboard models.</span></div>
+      <div class="metric"><strong>No static export</strong><span>GitHub Pages tab is source preview plus run shape.</span></div>
+    </section>
+
+    <section class="body-grid">
+      <div class="panel">
+        <h2>Bakeoff fit</h2>
+        <ul>
+          <li>Dashboard is authored as <code>fusion-issue-health.dashboard.sql</code>.</li>
+          <li>SQL uses Shaper casts such as <code>::SECTION</code>, <code>::DROPDOWN_MULTI</code>, <code>::LINECHART</code>, and <code>::BARCHART_STACKED</code>.</li>
+          <li>Shared semantic layer stays in dbt tables like <code>summary_kpis</code>, <code>cumulative_flow</code>, and <code>open_issues_table</code>.</li>
+          <li>Local live rendering starts from <code>dashboard/shaper</code> with Shaper pointed at a DuckDB or MotherDuck-backed database.</li>
+        </ul>
+        <p class="small">Generated from <code>{SOURCE.name}</code> and <code>{CONFIG.name}</code>.</p>
+      </div>
+      <div class="panel">
+        <h2>Dashboard source</h2>
+        <pre><code>{escaped_sql}</code></pre>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    sql = load_source()
+    TARGET.write_text(render_page(sql))
+    print(f"Rendered {SOURCE} -> {TARGET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/shaper/fusion-issue-health.dashboard.sql
+++ b/dashboard/shaper/fusion-issue-health.dashboard.sql
@@ -1,0 +1,104 @@
+-- shaperid:fusion_issue_health_bakeoff
+
+SELECT 'dbt-fusion issue health'::SECTION;
+
+SELECT 'Open source Shaper dashboard source for the bakeoff. Runs on the shared dbt dashboard marts in DuckDB or MotherDuck.'::TEXT_SMALL;
+
+CREATE TEMP VIEW scoped_issues AS (
+  SELECT *
+  FROM fct_issues
+  WHERE issue_category != 'epic'
+);
+
+SELECT 'Issue category'::LABEL;
+
+SELECT
+  issue_category::DROPDOWN_MULTI AS issue_category,
+  count(*)::HINT
+FROM scoped_issues
+WHERE state = 'OPEN'
+GROUP BY issue_category
+ORDER BY issue_category;
+
+CREATE TEMP VIEW filtered_issues AS (
+  SELECT *
+  FROM scoped_issues
+  WHERE issue_category IN getvariable('issue_category')
+);
+
+SELECT open_issues AS "Open Issues"
+FROM summary_kpis;
+
+SELECT (closed_4w - opened_4w) AS "Net Flow (4wk)"
+FROM summary_kpis;
+
+SELECT rolling_median_close_days AS "Median Close (days)"
+FROM summary_kpis;
+
+SELECT coalesce(pct_responded_48h / 100.0, 0)::GAUGE_PERCENT AS "48h Response SLA"
+FROM summary_kpis;
+
+SELECT 'Cumulative issue flow'::LABEL;
+
+SELECT
+  week::DATE::XAXIS,
+  cumulative_opened::LINECHART AS "Issues",
+  'opened'::CATEGORY
+FROM cumulative_flow
+UNION ALL
+SELECT
+  week::DATE::XAXIS,
+  cumulative_closed::LINECHART AS "Issues",
+  'closed'::CATEGORY
+FROM cumulative_flow
+ORDER BY 1, 3;
+
+SELECT 'Open issue age by category'::LABEL;
+
+SELECT
+  age_bucket::XAXIS AS "Age",
+  issue_count::BARCHART_STACKED AS "Issues",
+  issue_category::CATEGORY
+FROM age_distribution
+WHERE issue_category IN getvariable('issue_category')
+ORDER BY
+  CASE age_bucket
+    WHEN '0-7d' THEN 1
+    WHEN '8-30d' THEN 2
+    WHEN '31-90d' THEN 3
+    WHEN '91-180d' THEN 4
+    ELSE 5
+  END,
+  issue_category;
+
+SELECT 'First response time percentiles'::LABEL;
+
+SELECT
+  week::DATE::XAXIS,
+  p50::LINECHART AS "Median hours"
+FROM response_pctiles
+ORDER BY week;
+
+SELECT ('fusion-open-issues-' || today())::DOWNLOAD_CSV AS "CSV";
+
+SELECT *
+FROM open_issues_table
+WHERE type IN getvariable('issue_category')
+ORDER BY age_days DESC;
+
+SELECT 'Oldest open issues'::LABEL;
+
+SELECT
+  "#",
+  title,
+  type,
+  age_days,
+  reactions,
+  comments,
+  milestone
+FROM open_issues_table
+WHERE type IN getvariable('issue_category')
+ORDER BY age_days DESC
+LIMIT 20;
+
+SELECT 'https://github.com/dbt-labs/dbt-fusion/issues'::FOOTER_LINK;

--- a/dashboard/shaper/index.html
+++ b/dashboard/shaper/index.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shaper | dbt-fusion Issue Analysis</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #202124;
+      background: #f6f7fb;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 34px 20px 56px;
+    }
+    header {
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+      gap: 28px;
+      align-items: center;
+      margin-bottom: 28px;
+    }
+    header > *,
+    .body-grid > * {
+      min-width: 0;
+    }
+    h1 {
+      margin: 0 0 10px;
+      font-size: clamp(2.2rem, 5vw, 4rem);
+      line-height: 1;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 1.05rem;
+    }
+    p {
+      margin: 0;
+      line-height: 1.55;
+      color: #3f4550;
+    }
+    a { color: #145ea8; }
+    .eyebrow {
+      margin-bottom: 10px;
+      color: #6b4b12;
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .hero-text {
+      font-size: 1.08rem;
+      max-width: 680px;
+    }
+    .hero-image {
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
+      border: 1px solid #d8dde7;
+      border-radius: 8px;
+      background: #fff;
+      box-shadow: 0 18px 44px rgba(33, 41, 54, 0.14);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }
+    .actions a {
+      display: inline-flex;
+      min-height: 38px;
+      align-items: center;
+      padding: 0 13px;
+      border: 1px solid #b8c4d8;
+      border-radius: 6px;
+      background: #fff;
+      color: #173c66;
+      font-weight: 650;
+      text-decoration: none;
+    }
+    .panel {
+      min-width: 0;
+      border: 1px solid #d8dde7;
+      border-radius: 8px;
+      background: #fff;
+      padding: 18px;
+      box-shadow: 0 8px 24px rgba(33, 41, 54, 0.07);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .metric {
+      min-width: 0;
+      min-height: 96px;
+      border: 1px solid #dce2ec;
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcff;
+    }
+    .metric strong {
+      display: block;
+      margin-bottom: 7px;
+      font-size: 1.05rem;
+    }
+    .metric span {
+      display: block;
+      color: #667085;
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }
+    .body-grid {
+      display: grid;
+      grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
+      gap: 16px;
+      align-items: start;
+    }
+    ul {
+      margin: 0;
+      padding-left: 18px;
+      color: #3f4550;
+      line-height: 1.55;
+    }
+    code {
+      padding: 0.08rem 0.28rem;
+      border-radius: 4px;
+      background: #eef3ff;
+      font-size: 0.93em;
+    }
+    pre {
+      max-width: 100%;
+      max-height: 620px;
+      margin: 0;
+      overflow: auto;
+      border-radius: 6px;
+      background: #111827;
+      color: #e9edf7;
+      padding: 16px;
+      font-size: 0.86rem;
+      line-height: 1.45;
+      white-space: pre;
+    }
+    .small {
+      color: #667085;
+      font-size: 0.9rem;
+    }
+    @media (max-width: 1050px) {
+      header,
+      .body-grid {
+        grid-template-columns: 1fr;
+      }
+      .grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    @media (max-width: 640px) {
+      header,
+      .body-grid,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+      main {
+        padding: 24px 14px 40px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <div class="eyebrow">Server-backed SQL dashboard</div>
+        <h1>Shaper</h1>
+        <p class="hero-text">Open source Shaper joins the bakeoff as a SQL-first DuckDB dashboard. This tab ships the tracked <code>.dashboard.sql</code> source and makes the GitHub Pages limitation explicit: Shaper renders from a live Shaper server, not a static export bundle.</p>
+        <div class="actions">
+          <a href="fusion-issue-health.dashboard.sql">Dashboard SQL</a>
+          <a href="shaper.json">shaper.json</a>
+          <a href="https://taleshape.com/shaper/docs/" target="_blank" rel="noreferrer">Docs</a>
+          <a href="https://github.com/taleshape-com/shaper" target="_blank" rel="noreferrer">Source</a>
+        </div>
+      </div>
+      <img class="hero-image" src="https://taleshape.com/images/session_dashboard.png" alt="Shaper dashboard screenshot">
+    </header>
+
+    <section class="grid" aria-label="Shaper tab facts">
+      <div class="metric"><strong>21</strong><span>SQL statements in the tracked Shaper dashboard file.</span></div>
+      <div class="metric"><strong>DuckDB</strong><span>Runtime engine expected by Shaper and this repo.</span></div>
+      <div class="metric"><strong>dbt marts</strong><span>Queries stay on shared dashboard models.</span></div>
+      <div class="metric"><strong>No static export</strong><span>GitHub Pages tab is source preview plus run shape.</span></div>
+    </section>
+
+    <section class="body-grid">
+      <div class="panel">
+        <h2>Bakeoff fit</h2>
+        <ul>
+          <li>Dashboard is authored as <code>fusion-issue-health.dashboard.sql</code>.</li>
+          <li>SQL uses Shaper casts such as <code>::SECTION</code>, <code>::DROPDOWN_MULTI</code>, <code>::LINECHART</code>, and <code>::BARCHART_STACKED</code>.</li>
+          <li>Shared semantic layer stays in dbt tables like <code>summary_kpis</code>, <code>cumulative_flow</code>, and <code>open_issues_table</code>.</li>
+          <li>Local live rendering starts from <code>dashboard/shaper</code> with Shaper pointed at a DuckDB or MotherDuck-backed database.</li>
+        </ul>
+        <p class="small">Generated from <code>fusion-issue-health.dashboard.sql</code> and <code>shaper.json</code>.</p>
+      </div>
+      <div class="panel">
+        <h2>Dashboard source</h2>
+        <pre><code>-- shaperid:fusion_issue_health_bakeoff
+
+SELECT &#x27;dbt-fusion issue health&#x27;::SECTION;
+
+SELECT &#x27;Open source Shaper dashboard source for the bakeoff. Runs on the shared dbt dashboard marts in DuckDB or MotherDuck.&#x27;::TEXT_SMALL;
+
+CREATE TEMP VIEW scoped_issues AS (
+  SELECT *
+  FROM fct_issues
+  WHERE issue_category != &#x27;epic&#x27;
+);
+
+SELECT &#x27;Issue category&#x27;::LABEL;
+
+SELECT
+  issue_category::DROPDOWN_MULTI AS issue_category,
+  count(*)::HINT
+FROM scoped_issues
+WHERE state = &#x27;OPEN&#x27;
+GROUP BY issue_category
+ORDER BY issue_category;
+
+CREATE TEMP VIEW filtered_issues AS (
+  SELECT *
+  FROM scoped_issues
+  WHERE issue_category IN getvariable(&#x27;issue_category&#x27;)
+);
+
+SELECT open_issues AS &quot;Open Issues&quot;
+FROM summary_kpis;
+
+SELECT (closed_4w - opened_4w) AS &quot;Net Flow (4wk)&quot;
+FROM summary_kpis;
+
+SELECT rolling_median_close_days AS &quot;Median Close (days)&quot;
+FROM summary_kpis;
+
+SELECT coalesce(pct_responded_48h / 100.0, 0)::GAUGE_PERCENT AS &quot;48h Response SLA&quot;
+FROM summary_kpis;
+
+SELECT &#x27;Cumulative issue flow&#x27;::LABEL;
+
+SELECT
+  week::DATE::XAXIS,
+  cumulative_opened::LINECHART AS &quot;Issues&quot;,
+  &#x27;opened&#x27;::CATEGORY
+FROM cumulative_flow
+UNION ALL
+SELECT
+  week::DATE::XAXIS,
+  cumulative_closed::LINECHART AS &quot;Issues&quot;,
+  &#x27;closed&#x27;::CATEGORY
+FROM cumulative_flow
+ORDER BY 1, 3;
+
+SELECT &#x27;Open issue age by category&#x27;::LABEL;
+
+SELECT
+  age_bucket::XAXIS AS &quot;Age&quot;,
+  issue_count::BARCHART_STACKED AS &quot;Issues&quot;,
+  issue_category::CATEGORY
+FROM age_distribution
+WHERE issue_category IN getvariable(&#x27;issue_category&#x27;)
+ORDER BY
+  CASE age_bucket
+    WHEN &#x27;0-7d&#x27; THEN 1
+    WHEN &#x27;8-30d&#x27; THEN 2
+    WHEN &#x27;31-90d&#x27; THEN 3
+    WHEN &#x27;91-180d&#x27; THEN 4
+    ELSE 5
+  END,
+  issue_category;
+
+SELECT &#x27;First response time percentiles&#x27;::LABEL;
+
+SELECT
+  week::DATE::XAXIS,
+  p50::LINECHART AS &quot;Median hours&quot;
+FROM response_pctiles
+ORDER BY week;
+
+SELECT (&#x27;fusion-open-issues-&#x27; || today())::DOWNLOAD_CSV AS &quot;CSV&quot;;
+
+SELECT *
+FROM open_issues_table
+WHERE type IN getvariable(&#x27;issue_category&#x27;)
+ORDER BY age_days DESC;
+
+SELECT &#x27;Oldest open issues&#x27;::LABEL;
+
+SELECT
+  &quot;#&quot;,
+  title,
+  type,
+  age_days,
+  reactions,
+  comments,
+  milestone
+FROM open_issues_table
+WHERE type IN getvariable(&#x27;issue_category&#x27;)
+ORDER BY age_days DESC
+LIMIT 20;
+
+SELECT &#x27;https://github.com/dbt-labs/dbt-fusion/issues&#x27;::FOOTER_LINK;</code></pre>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/dashboard/shaper/shaper.json
+++ b/dashboard/shaper/shaper.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://localhost:5454",
+  "directory": "."
+}

--- a/tests/test_shaper_dashboard.py
+++ b/tests/test_shaper_dashboard.py
@@ -1,0 +1,69 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_HTML = REPO_ROOT / "dashboard" / "index.html"
+MAKEFILE = REPO_ROOT / "Makefile"
+PR_PREVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-preview.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dashboard.yml"
+SHAPER_DIR = REPO_ROOT / "dashboard" / "shaper"
+SHAPER_SQL = SHAPER_DIR / "fusion-issue-health.dashboard.sql"
+SHAPER_BUILD = SHAPER_DIR / "build.py"
+
+
+class ShaperDashboardTests(unittest.TestCase):
+    def test_bakeoff_tab_points_to_shaper_static_page(self) -> None:
+        content = INDEX_HTML.read_text()
+        self.assertIn("Shaper", content)
+        self.assertIn('data-src="shaper/index.html"', content)
+        self.assertIn('data-tab="shaper"', content)
+
+    def test_makefile_and_workflows_build_shaper_tab(self) -> None:
+        makefile = MAKEFILE.read_text()
+        preview = PR_PREVIEW_WORKFLOW.read_text()
+        ci = CI_WORKFLOW.read_text()
+        deploy = DEPLOY_WORKFLOW.read_text()
+
+        self.assertIn("shaper", makefile)
+        self.assertIn("uv run python3 dashboard/shaper/build.py", makefile)
+        for content in (preview, ci, deploy):
+            self.assertIn("uv run python3 dashboard/shaper/build.py", content)
+
+        self.assertIn("preview/shaper", preview)
+        self.assertIn("| Shaper | `shaper/index.html` |", preview)
+
+    def test_shaper_dashboard_source_uses_shaper_sql_types(self) -> None:
+        sql = SHAPER_SQL.read_text()
+        self.assertTrue(sql.startswith("-- shaperid:"))
+        for token in (
+            "::SECTION",
+            "::DROPDOWN_MULTI",
+            "::HINT",
+            "::GAUGE_PERCENT",
+            "::LINECHART",
+            "::BARCHART_STACKED",
+            "::DOWNLOAD_CSV",
+            "::FOOTER_LINK",
+            "getvariable('issue_category')",
+        ):
+            self.assertIn(token, sql)
+
+    def test_shaper_static_page_builder_renders_source(self) -> None:
+        spec = importlib.util.spec_from_file_location("shaper_build", SHAPER_BUILD)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        sql = SHAPER_SQL.read_text()
+        html = module.render_page(sql)
+        self.assertIn("Open source Shaper joins the bakeoff", html)
+        self.assertIn("fusion-issue-health.dashboard.sql", html)
+        self.assertIn("&quot;Open Issues&quot;", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Shaper tab to the bakeoff shell
- ship tracked Shaper `.dashboard.sql` source plus static source-preview page
- wire Shaper into About, Makefile, CI, deploy, and PR preview artifact

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

## Tests
- `uv run python3 -m unittest discover -s tests`
- `uvx --from shaper-bin shaper ids --config shaper.json`