### PR TITLE
Consolidate Prefab dashboard themes

### DIFF
--- a/dashboard/about.html
+++ b/dashboard/about.html
@@ -108,7 +108,7 @@
 <h2>What this repo is testing</h2>
 <ul>
 <li>Same analytics problem, implemented across multiple static, static-friendly, and server-backed dashboard frameworks.</li>
-<li>Eleven dashboard variants sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
+<li>The dashboard variants sit on top of the same dbt <code>models/dashboard/</code> layer, so comparison is closer to apples-to-apples.</li>
 <li>Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.</li>
 <li>Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.</li>
 </ul>
@@ -121,9 +121,10 @@
 </ol>
 <h2>Tools in the bakeoff</h2>
 <p><strong>Core bakeoff frameworks:</strong> Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo, DAC, Shaper.</p>
-<p><strong>Side experiments:</strong> Prefab MySpace and Quarto.</p>
+<p><strong>Side experiments:</strong> Prefab MySpace, Prefab Windows 2000, and Quarto.</p>
 <p><strong>Data stack:</strong> dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.</p>
-<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=prefab-myspace">Prefab MySpace</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=mdv">MDV</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>, <a href="./?tab=dac">DAC</a>, <a href="./?tab=shaper">Shaper</a>.</p>
+<p><strong>Direct links:</strong> <a href="./?tab=prefab">Prefab</a>, <a href="./?tab=ggsql">ggsql</a>, <a href="./?tab=mviz">mviz</a>, <a href="./?tab=mdv">MDV</a>, <a href="./?tab=observable">Observable</a>, <a href="./?tab=evidence">Evidence.dev</a>, <a href="./?tab=marimo">Marimo</a>, <a href="./?tab=quarto">Quarto</a>, <a href="./?tab=dac">DAC</a>, <a href="./?tab=shaper">Shaper</a>.</p>
+<p><strong>Prefab themes:</strong> <a href="./?tab=prefab">Vanilla</a>, <a href="./?tab=prefab&amp;theme=myspace">MySpace</a>, <a href="./?tab=prefab&amp;theme=windows-2000">Windows 2000</a>.</p>
 <h2>Main challenge</h2>
 <p>Hard part is not charting. Hard part is keeping business logic out of the dashboard. Agents do this. Humans do this too. The dashboard layer always tempts you to tuck a little metric logic, filtering logic, or status logic into the page because it feels faster in the moment. But once that starts, the dashboard becomes the semantic layer by accident.</p>
 <p>The discipline here is to keep metric definitions, joins, and business rules in dbt whenever possible, then let the dashboard focus on layout, interaction, and presentation. When that boundary holds, the bakeoff is easier to compare, easier to diff, and easier to swap between tools.</p>
@@ -152,7 +153,7 @@
 <tr>
 <td>Build-time bake</td>
 <td>SQL runs in CI against MotherDuck and rows are baked into static artifacts.</td>
-<td>Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC</td>
+<td>Prefab, Prefab themes, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC</td>
 </tr>
 <tr>
 <td>Render-time query</td>

--- a/dashboard/about.md
+++ b/dashboard/about.md
@@ -17,7 +17,7 @@ I expected a couple of options. I was surprised by how many there are. Along the
 ## What this repo is testing
 
 - Same analytics problem, implemented across multiple static, static-friendly, and server-backed dashboard frameworks.
-- Eleven dashboard variants sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
+- The dashboard variants sit on top of the same dbt `models/dashboard/` layer, so comparison is closer to apples-to-apples.
 - Shared data layer runs on DuckDB locally and MotherDuck in deployed builds.
 - Each framework makes different choices about authoring, transport, layout, interactivity, and build shape.
 
@@ -32,11 +32,13 @@ I expected a couple of options. I was surprised by how many there are. Along the
 
 **Core bakeoff frameworks:** Prefab, Evidence.dev, Observable Framework, ggsql + Vega-Lite, mviz, MDV, Marimo, DAC, Shaper.
 
-**Side experiments:** Prefab MySpace and Quarto.
+**Side experiments:** Prefab MySpace, Prefab Windows 2000, and Quarto.
 
 **Data stack:** dlt, dbt Fusion, DuckDB, MotherDuck, GitHub Actions, GitHub Pages.
 
-**Direct links:** [Prefab](./?tab=prefab), [Prefab MySpace](./?tab=prefab-myspace), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [MDV](./?tab=mdv), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto), [DAC](./?tab=dac), [Shaper](./?tab=shaper).
+**Direct links:** [Prefab](./?tab=prefab), [ggsql](./?tab=ggsql), [mviz](./?tab=mviz), [MDV](./?tab=mdv), [Observable](./?tab=observable), [Evidence.dev](./?tab=evidence), [Marimo](./?tab=marimo), [Quarto](./?tab=quarto), [DAC](./?tab=dac), [Shaper](./?tab=shaper).
+
+**Prefab themes:** [Vanilla](./?tab=prefab), [MySpace](./?tab=prefab&theme=myspace), [Windows 2000](./?tab=prefab&theme=windows-2000).
 
 ## Main challenge
 
@@ -62,7 +64,7 @@ The interesting choices are usually in the first three. Once query engine and tr
 
 | Mode | What happens | Frameworks |
 |---|---|---|
-| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab MySpace, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC |
+| Build-time bake | SQL runs in CI against MotherDuck and rows are baked into static artifacts. | Prefab, Prefab themes, mviz, MDV, ggsql, Observable, Marimo, Quarto, DAC |
 | Render-time query | Browser reruns page SQL against shipped Parquet through DuckDB-WASM. | Evidence.dev |
 | Server-backed runtime | SQL lives in Git, but rendering expects a live app server rather than a GitHub Pages bundle. | Shaper |
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -39,21 +39,25 @@
       scrollbar-width: thin;
     }
 
-    nav button {
+    nav button,
+    .subnav button {
       padding: 7px 18px;
       border: 1px solid transparent;
-      border-bottom: none;
       background: transparent;
       color: #888;
-      border-radius: 5px 5px 0 0;
       cursor: pointer;
       font-size: 0.875rem;
       font-family: inherit;
       transition: color 0.1s;
-      position: relative;
-      bottom: -1px;
       flex: 0 0 auto;
       white-space: nowrap;
+    }
+
+    nav button {
+      border-bottom: none;
+      border-radius: 5px 5px 0 0;
+      position: relative;
+      bottom: -1px;
     }
 
     nav button:hover {
@@ -64,6 +68,38 @@
       background: #fff;
       color: #111;
       border-color: #333;
+      font-weight: 600;
+    }
+
+    .subnav {
+      display: flex;
+      gap: 6px;
+      padding: 9px 0 10px;
+      overflow-x: auto;
+      scrollbar-width: thin;
+    }
+
+    .subnav[hidden] {
+      display: none;
+    }
+
+    .subnav button {
+      padding: 5px 12px;
+      border-color: #333;
+      border-radius: 4px;
+      background: #1b1b1b;
+      font-size: 0.8rem;
+    }
+
+    .subnav button:hover {
+      color: #ddd;
+      border-color: #555;
+    }
+
+    .subnav button.active {
+      background: #e8e8e8;
+      color: #111;
+      border-color: #555;
       font-weight: 600;
     }
 
@@ -79,10 +115,8 @@
   <!-- Deploy smoke test: keep dashboard/** path change behaviorless. -->
   <header>
     <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
-    <nav>
+    <nav class="main-tabs" aria-label="Dashboard framework">
       <button class="active" data-src="prefab/app.html" data-tab="prefab" onclick="switchTab(this)">Prefab</button>
-      <button data-src="prefab/app_myspace.html" data-tab="prefab-myspace" onclick="switchTab(this)">Prefab MySpace</button>
-      <button data-src="prefab/app_windows_2000.html" data-tab="prefab-windows-2000" onclick="switchTab(this)">Prefab Windows 2000</button>
       <button data-src="ggsql/index.html" data-tab="ggsql" onclick="switchTab(this)">ggsql + Vega-Lite</button>
       <button data-src="mviz/index.html" data-tab="mviz" onclick="switchTab(this)">mviz</button>
       <button data-src="mdv/index.html" data-tab="mdv" onclick="switchTab(this)">MDV</button>
@@ -94,22 +128,66 @@
       <button data-src="shaper/index.html" data-tab="shaper" onclick="switchTab(this)">Shaper</button>
       <button data-src="about.html" data-tab="about" onclick="switchTab(this)">About</button>
     </nav>
+    <div class="subnav" id="prefab-themes" aria-label="Prefab theme">
+      <button class="active" data-src="prefab/app.html" data-theme="vanilla" onclick="switchPrefabTheme(this)">Vanilla</button>
+      <button data-src="prefab/app_myspace.html" data-theme="myspace" onclick="switchPrefabTheme(this)">MySpace</button>
+      <button data-src="prefab/app_windows_2000.html" data-theme="windows-2000" onclick="switchPrefabTheme(this)">Windows 2000</button>
+    </div>
   </header>
   <iframe id="frame" src="prefab/app.html" title="Dashboard"></iframe>
 
   <script>
-    const tabs = Array.from(document.querySelectorAll('nav button'));
+    const tabs = Array.from(document.querySelectorAll('.main-tabs button'));
+    const prefabThemes = Array.from(document.querySelectorAll('#prefab-themes button'));
+    const prefabThemeBar = document.getElementById('prefab-themes');
     const frame = document.getElementById('frame');
+    const legacyPrefabThemeAliases = {
+      "prefab-myspace": "myspace",
+      "prefab-windows-2000": "windows-2000",
+    };
 
-    function switchTab(btn) {
+    function setActive(buttons, active) {
+      buttons.forEach(button => button.classList.toggle('active', button === active));
+    }
+
+    function activePrefabTheme() {
+      return prefabThemes.find(button => button.classList.contains('active')) || prefabThemes[0];
+    }
+
+    function switchTab(btn, options = {}) {
       tabs.forEach(b => b.classList.remove('active'));
       btn.classList.add('active');
-      frame.src = btn.dataset.src;
-      frame.title = btn.textContent.trim();
+      const isPrefab = btn.dataset.tab === "prefab";
+      prefabThemeBar.hidden = !isPrefab;
 
+      if (isPrefab) {
+        const themeName = options.theme || activePrefabTheme().dataset.theme || "vanilla";
+        const theme = prefabThemes.find(button => button.dataset.theme === themeName) || prefabThemes[0];
+        setActive(prefabThemes, theme);
+        frame.src = theme.dataset.src;
+        frame.title = `Prefab ${theme.textContent.trim()}`;
+        updateUrl("prefab", theme.dataset.theme);
+      } else {
+        frame.src = btn.dataset.src;
+        frame.title = btn.textContent.trim();
+        updateUrl(btn.dataset.tab);
+      }
+    }
+
+    function switchPrefabTheme(btn) {
+      const prefabTab = tabs.find(button => button.dataset.tab === "prefab");
+      switchTab(prefabTab, { theme: btn.dataset.theme });
+    }
+
+    function updateUrl(tab, theme) {
       const url = new URL(window.location);
-      url.searchParams.set("tab", btn.dataset.tab);
-      url.hash = btn.dataset.tab;
+      url.searchParams.set("tab", tab);
+      if (theme && theme !== "vanilla") {
+        url.searchParams.set("theme", theme);
+      } else {
+        url.searchParams.delete("theme");
+      }
+      url.hash = tab;
       if (window.location.search !== url.search || window.location.hash !== url.hash) {
         history.replaceState(null, "", url);
       }
@@ -117,11 +195,20 @@
 
     function loadTabFromHash() {
       const params = new URLSearchParams(window.location.search);
-      const tab = params.get("tab") || window.location.hash.replace(/^#/, "");
+      let tab = params.get("tab") || window.location.hash.replace(/^#/, "");
+      let theme = params.get("theme");
       if (!tab) return;
 
+      if (legacyPrefabThemeAliases[tab]) {
+        theme = legacyPrefabThemeAliases[tab];
+        tab = "prefab";
+      }
+      if (tab === "prefab" && !theme) {
+        theme = "vanilla";
+      }
+
       const match = tabs.find(btn => btn.dataset.tab === tab);
-      if (match) switchTab(match);
+      if (match) switchTab(match, { theme });
     }
 
     loadTabFromHash();

--- a/tests/test_prefab_windows_2000.py
+++ b/tests/test_prefab_windows_2000.py
@@ -14,10 +14,13 @@ LOCAL_DB = REPO_ROOT / "data" / "fusion_issues.duckdb"
 
 
 class PrefabWindows2000Tests(unittest.TestCase):
-    def test_bakeoff_tab_points_to_windows_2000_export(self) -> None:
+    def test_bakeoff_prefab_tab_has_windows_2000_theme(self) -> None:
         content = INDEX_HTML.read_text()
-        self.assertIn("Prefab Windows 2000", content)
+        self.assertIn('id="prefab-themes"', content)
+        self.assertIn('data-tab="prefab"', content)
+        self.assertIn('data-theme="windows-2000"', content)
         self.assertIn('data-src="prefab/app_windows_2000.html"', content)
+        self.assertIn('"prefab-windows-2000": "windows-2000"', content)
 
     def test_makefile_exports_windows_2000_prefab(self) -> None:
         content = MAKEFILE.read_text()


### PR DESCRIPTION
## Summary
- collapse the three Prefab entries into one top-level tab
- add a Prefab theme switcher for Vanilla, MySpace, and Windows 2000
- preserve legacy Prefab MySpace and Windows 2000 deep links
- refresh About links and coverage

## Validation
- uv run python3 -m unittest tests/test_prefab_windows_2000.py
- make prefab

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)