### PR TITLE
Cache dashboard build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dashboard-npm-
 
       - name: Install dependencies
         run: uv sync --dev
@@ -41,13 +52,11 @@ jobs:
           uv run prefab export dashboard/prefab/app_myspace.py -o /tmp/prefab_myspace.html
           uv run prefab export dashboard/prefab/app_windows_2000.py -o /tmp/prefab_windows_2000.html
 
-      - name: Smoke-test mviz
+      - name: Smoke-test npm dashboards
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/mviz
-          uv run python generate_data.py
-          npx --yes mviz@1.6.7 dashboard.md -o /tmp/mviz.html
+          EVIDENCE_BASE_PATH: /evidence/build
+        run: npm run build:npm-dashboards
 
       - name: Smoke-test ggsql
         env:
@@ -59,25 +68,6 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o /tmp/marimo.html
-
-      - name: Smoke-test Observable
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/observable
-          npm ci --silent
-          npm run build
-
-      - name: Smoke-test Evidence
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          EVIDENCE_BASE_PATH: /evidence/build
-        run: |
-          uv run python3 dashboard/evidence/generate_sources.py
-          cd dashboard/evidence
-          npm ci --legacy-peer-deps --silent
-          ./node_modules/.bin/evidence sources
-          npm run build
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,11 +1,15 @@
 name: Deploy Dashboard to GitHub Pages
 
+env:
+  MDV_SHA: b9d5a8c1bb66b094a8745775cb9bf1389f08403f
+
 on:
   # Re-deploy when dashboard code changes on main
   push:
     branches: [main]
     paths:
       - 'dashboard/**'
+      - 'package.json'
       - '.github/workflows/deploy-dashboard.yml'
   # Run daily at 6am UTC
   schedule:
@@ -30,6 +34,25 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dashboard-npm-
+
+      - name: Cache MDV build
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/fusion-mdv-cache
+          key: ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-${{ hashFiles('dashboard/mdv/build.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-
 
       - name: Install dependencies
         run: uv sync
@@ -54,17 +77,16 @@ jobs:
             uv run prefab export "$f" -o "dashboard/prefab/${name}.html" || true
           done
 
-      - name: Build mviz dashboard
+      - name: Build npm dashboards
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/mviz
-          uv run python generate_data.py
-          npx --yes mviz@1.6.7 dashboard.md -o index.html
+          EVIDENCE_BASE_PATH: /evidence/build
+        run: npm run build:npm-dashboards
 
       - name: Build MDV dashboard
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          MDV_CACHE_DIR: ${{ runner.temp }}/fusion-mdv-cache/mdv-${{ env.MDV_SHA }}
         run: bash dashboard/mdv/build.sh
 
       - name: Build ggsql dashboard
@@ -72,29 +94,6 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           FUSION_DB: md:fusion_issues
         run: uv run dashboard/ggsql/build.py
-
-      - name: Build Observable Framework dashboard
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/observable
-          npm ci
-          npm run build
-
-      - name: Configure Evidence.dev
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          EVIDENCE_BASE_PATH: /evidence/build
-        run: uv run python3 dashboard/evidence/generate_sources.py
-
-      - name: Build Evidence.dev dashboard
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/evidence
-          npm ci --legacy-peer-deps
-          ./node_modules/.bin/evidence sources
-          npm run build
 
       - name: Export Marimo dashboard
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,5 +1,8 @@
 name: PR Dashboard Preview
 
+env:
+  MDV_SHA: b9d5a8c1bb66b094a8745775cb9bf1389f08403f
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -16,6 +19,25 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dashboard-npm-
+
+      - name: Cache MDV build
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/fusion-mdv-cache
+          key: ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-${{ hashFiles('dashboard/mdv/build.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-
 
       - name: Install dependencies
         run: uv sync --dev
@@ -48,18 +70,16 @@ jobs:
           uv run prefab export dashboard/prefab/app_myspace.py -o preview/prefab/app_myspace.html
           uv run prefab export dashboard/prefab/app_windows_2000.py -o preview/prefab/app_windows_2000.html
 
-      - name: Build mviz dashboard
+      - name: Build npm dashboard previews
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          mkdir -p preview/mviz
-          cd dashboard/mviz
-          uv run python generate_data.py
-          npx --yes mviz@1.6.7 dashboard.md -o ../../preview/mviz/index.html
+          EVIDENCE_BASE_PATH: /evidence/build
+        run: npm run build:npm-dashboards:preview
 
       - name: Build MDV dashboard
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          MDV_CACHE_DIR: ${{ runner.temp }}/fusion-mdv-cache/mdv-${{ env.MDV_SHA }}
         run: |
           mkdir -p preview/mdv
           bash dashboard/mdv/build.sh
@@ -78,29 +98,6 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o preview/marimo.html
-
-      - name: Build Observable Framework dashboard
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: |
-          cd dashboard/observable
-          npm ci --silent
-          npm run build
-          mkdir -p ../preview/observable
-          cp -r dist/* ../preview/observable/
-
-      - name: Build Evidence.dev dashboard
-        env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-          EVIDENCE_BASE_PATH: /evidence/build
-        run: |
-          uv run python3 dashboard/evidence/generate_sources.py
-          cd dashboard/evidence
-          npm ci --legacy-peer-deps --silent
-          ./node_modules/.bin/evidence sources
-          npm run build
-          mkdir -p ../../preview/evidence
-          cp -r build/* ../../preview/evidence/
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz mdv marimo observable evidence quarto dac shaper kill-server clean help
+.PHONY: serve build about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,7 +12,7 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql mviz mdv marimo observable evidence quarto dac shaper
+build: about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -40,8 +40,11 @@ ggsql:
 
 ## mviz         Generate data files and render mviz dashboard
 mviz:
-	uv run python3 dashboard/mviz/generate_data.py
-	npx --yes mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html
+	npm run build:mviz
+
+## npm-dashboards Build mviz, Observable, and Evidence in one npm command
+npm-dashboards:
+	npm run build:npm-dashboards
 
 ## mdv          Generate data files and render MDV dashboard
 mdv:
@@ -53,12 +56,13 @@ marimo:
 
 ## observable   Build Observable Framework dashboard (requires npm)
 observable:
-	cd dashboard/observable && npm run build
+	npm --prefix dashboard/observable ci --silent
+	npm run build:observable
 
 ## evidence     Build Evidence.dev dashboard (requires MOTHERDUCK_TOKEN + npm)
 evidence:
-	uv run python3 dashboard/evidence/generate_sources.py
-	cd dashboard/evidence && npm run build
+	npm --prefix dashboard/evidence ci --legacy-peer-deps --silent
+	npm run build:evidence
 
 ## quarto       Render Quarto dashboard to static HTML
 quarto:
@@ -96,5 +100,5 @@ help:
 	@echo ""
 	@echo "Notes:"
 	@echo "  Set MOTHERDUCK_TOKEN to build against MotherDuck instead of local DuckDB"
-	@echo "  observable and evidence require node_modules (run npm ci in each dir first)"
+	@echo "  npm-dashboards installs nested Node dependencies before building"
 	@echo "  dac requires the dac and bruin CLIs"

--- a/dashboard/evidence/package.json
+++ b/dashboard/evidence/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "evidence dev",
     "build": "evidence build",
+    "sources": "evidence sources",
     "preview": "evidence preview",
     "postinstall": "patch-package"
   },

--- a/dashboard/mdv/build.sh
+++ b/dashboard/mdv/build.sh
@@ -3,10 +3,14 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MDV_SHA="${MDV_SHA:-b9d5a8c1bb66b094a8745775cb9bf1389f08403f}"
-MDV_CACHE_DIR="${MDV_CACHE_DIR:-${TMPDIR:-/tmp}/mdv-${MDV_SHA}}"
+MDV_CACHE_ROOT="${XDG_CACHE_HOME:-${HOME:-${TMPDIR:-/tmp}}/.cache}/fusion_issue_analysis"
+MDV_CACHE_DIR="${MDV_CACHE_DIR:-${MDV_CACHE_ROOT}/mdv-${MDV_SHA}}"
+NPM_CACHE_DIR="${npm_config_cache:-${NPM_CONFIG_CACHE:-${HOME:-${TMPDIR:-/tmp}}/.npm}}"
 
-export npm_config_cache="${npm_config_cache:-${TMPDIR:-/tmp}/npm-cache-mdv}"
+export npm_config_cache="$NPM_CACHE_DIR"
 export PUPPETEER_SKIP_DOWNLOAD="${PUPPETEER_SKIP_DOWNLOAD:-1}"
+
+mkdir -p "$(dirname "$MDV_CACHE_DIR")" "$npm_config_cache"
 
 if [ ! -d "$MDV_CACHE_DIR/.git" ]; then
   git clone https://github.com/drasimwagan/mdv.git "$MDV_CACHE_DIR"
@@ -14,12 +18,16 @@ fi
 
 git -C "$MDV_CACHE_DIR" fetch --depth 1 origin "$MDV_SHA"
 git -C "$MDV_CACHE_DIR" checkout --detach "$MDV_SHA"
-(
-  cd "$MDV_CACHE_DIR"
-  npm install --include-workspace-root --workspaces --package-lock=false --silent
-  npm run build --workspace @mdv/core --silent
-  npm run build --workspace @mdv/cli --silent
-)
+
+MDV_CLI="$MDV_CACHE_DIR/packages/mdv-cli/dist/index.js"
+if [ ! -f "$MDV_CLI" ] || [ ! -d "$MDV_CACHE_DIR/node_modules" ]; then
+  (
+    cd "$MDV_CACHE_DIR"
+    npm install --prefer-offline --no-audit --no-fund --include-workspace-root --workspaces --package-lock=false --silent
+    npm run build --workspace @mdv/core --silent
+    npm run build --workspace @mdv/cli --silent
+  )
+fi
 
 uv run python3 "$HERE/generate_data.py"
-node "$MDV_CACHE_DIR/packages/mdv-cli/dist/index.js" render "$HERE/dashboard.mdv" --out "$HERE/index.html"
+node "$MDV_CLI" render "$HERE/dashboard.mdv" --out "$HERE/index.html"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fusion-issue-analysis",
+  "private": true,
+  "scripts": {
+    "build:npm-dashboards": "npm run build:mviz && npm --prefix dashboard/observable ci --prefer-offline --no-audit --no-fund --silent && npm run build:observable && npm --prefix dashboard/evidence ci --legacy-peer-deps --prefer-offline --no-audit --no-fund --silent && npm run build:evidence",
+    "build:npm-dashboards:preview": "npm run build:npm-dashboards && mkdir -p preview/mviz preview/observable preview/evidence && cp dashboard/mviz/index.html preview/mviz/index.html && cp -R dashboard/observable/dist/. preview/observable/ && cp -R dashboard/evidence/build/. preview/evidence/",
+    "build:mviz": "uv run python3 dashboard/mviz/generate_data.py && npx --yes --prefer-offline mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html",
+    "build:observable": "npm --prefix dashboard/observable run build",
+    "build:evidence": "uv run python3 dashboard/evidence/generate_sources.py && npm --prefix dashboard/evidence run sources && npm --prefix dashboard/evidence run build"
+  }
+}


### PR DESCRIPTION
## Summary
- add one root npm build command for mviz, Observable, and Evidence
- cache shared npm downloads and uv dependencies in dashboard workflows
- cache the pinned MDV checkout/build and skip rebuild when already built

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

## Checks
- npm run build:npm-dashboards
- MDV_CACHE_DIR=/tmp/fusion-issue-analysis-mdv-test/mdv-b9d5a8c1bb66b094a8745775cb9bf1389f08403f bash dashboard/mdv/build.sh
- git diff --check