### PR TITLE
Clarify about page navigation

### DIFF
--- a/dashboard/about.html
+++ b/dashboard/about.html
@@ -95,9 +95,9 @@
   <main>
     <!-- Generated from dashboard/about.md. Do not edit dashboard/about.html directly. -->
     <p class="links">
-  <a href="./?tab=prefab" target="_top">Dashboard</a> ·
-  <a href="https://github.com/dataders/fusion_issue_analysis" target="_blank" rel="noreferrer">GitHub repo</a> ·
-  <a href="https://github.com/dbt-labs/dbt-fusion" target="_blank" rel="noreferrer">Upstream issues</a>
+  <a href="./?tab=prefab" target="_top">Open dashboards</a> ·
+  <a href="https://github.com/dataders/fusion_issue_analysis" target="_blank" rel="noreferrer">Source repo</a> ·
+  <a href="https://github.com/dataders/fusion_issue_analysis/tree/main/transform/models/dashboard" target="_blank" rel="noreferrer">Shared dbt models</a>
 </p>
 
 <h1>About this dashboard bakeoff</h1>

--- a/dashboard/about.md
+++ b/dashboard/about.md
@@ -1,7 +1,7 @@
 <p class="links">
-  <a href="./?tab=prefab" target="_top">Dashboard</a> ·
-  <a href="https://github.com/dataders/fusion_issue_analysis" target="_blank" rel="noreferrer">GitHub repo</a> ·
-  <a href="https://github.com/dbt-labs/dbt-fusion" target="_blank" rel="noreferrer">Upstream issues</a>
+  <a href="./?tab=prefab" target="_top">Open dashboards</a> ·
+  <a href="https://github.com/dataders/fusion_issue_analysis" target="_blank" rel="noreferrer">Source repo</a> ·
+  <a href="https://github.com/dataders/fusion_issue_analysis/tree/main/transform/models/dashboard" target="_blank" rel="noreferrer">Shared dbt models</a>
 </p>
 
 # About this dashboard bakeoff


### PR DESCRIPTION
## Summary
- Replace the About page top links with dashboard, source, and shared dbt model shortcuts
- Remove the upstream issues shortcut

## Validation
- `uv run python3 dashboard/render_about.py`
- `git diff --check -- dashboard/about.md dashboard/about.html`

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)