### PR TITLE
Fix Evidence x-axis, double title, and DAC empty chart

### DIFF
--- a/dashboard/evidence/pages/index.md
+++ b/dashboard/evidence/pages/index.md
@@ -1,9 +1,7 @@
 ---
 title: dbt-fusion Issue Health
+description: Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)
 ---
-
-
-# dbt-fusion Issue Health · Evidence.dev
 
 Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)
 
@@ -28,7 +26,7 @@ from summary_kpis
 ## Cumulative Issue Flow
 
 ```sql cumulative_flow
-select week, cumulative_opened, cumulative_closed from cumulative_flow order by week
+select CAST(week AS DATE) as week, cumulative_opened, cumulative_closed from cumulative_flow order by week
 ```
 
 <AreaChart
@@ -42,7 +40,7 @@ select week, cumulative_opened, cumulative_closed from cumulative_flow order by 
 ## Velocity & Response
 
 ```sql velocity
-select week, issue_category, median_days from velocity order by week
+select CAST(week AS DATE) as week, issue_category, median_days from velocity order by week
 ```
 
 <LineChart
@@ -54,7 +52,7 @@ select week, issue_category, median_days from velocity order by week
 />
 
 ```sql response_pctiles
-select week, p25, p50, p75 from response_pctiles order by week
+select CAST(week AS DATE) as week, p25, p50, p75 from response_pctiles order by week
 ```
 
 <LineChart


### PR DESCRIPTION
## Summary

- **Evidence x-axis**: All three time-series queries (`cumulative_flow`, `velocity`, `response_pctiles`) now cast the ISO string `week` column to `DATE`. Evidence auto-formats proper month/year ticks instead of cramming every `2024-01-14` string.
- **Evidence double title**: Removed the duplicate `# dbt-fusion Issue Health · Evidence.dev` H1 — the frontmatter `title:` already renders the page heading. Moved the subtitle inline below the frontmatter.
- **DAC empty chart**: `chart: pie` is not supported by Bruin DAC, leaving a blank slot next to the Cumulative Flow chart. Replaced with `chart: bar` (matching the other bar charts in the YAML).

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)