### PR TITLE
Make Prefab dashboard daily-operational for triage

### DIFF
--- a/dashboard/evidence/pages/index.md
+++ b/dashboard/evidence/pages/index.md
@@ -5,6 +5,43 @@ description: Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)
 
 Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)
 
+## Daily Triage Snapshot
+
+```sql operational_triage
+select
+    slipped_through_count,
+    triage_queue_count,
+    hard_blocker_count,
+    needs_repro_count,
+    repro_verified_count,
+    stale_count
+from issue_triage_health
+```
+
+<BigValue data={operational_triage} value="slipped_through_count" title="Slipped Through"/>
+<BigValue data={operational_triage} value="triage_queue_count" title="In Triage Queue"/>
+<BigValue data={operational_triage} value="hard_blocker_count" title="Hard Blockers"/>
+<BigValue data={operational_triage} value="needs_repro_count" title="Needs Repro"/>
+<BigValue data={operational_triage} value="repro_verified_count" title="Repro Verified"/>
+<BigValue data={operational_triage} value="stale_count" title="Stale"/>
+
+```sql oldest_untriaged
+select
+    issue_number,
+    title,
+    age_days,
+    issue_url
+from oldest_untriaged
+order by age_days desc
+```
+
+<DataTable data={oldest_untriaged} rows=25 title="Oldest Untriaged Issues">
+  <Column id="issue_number" title="#"/>
+  <Column id="title" title="Title"/>
+  <Column id="age_days" title="Age (days)"/>
+  <Column id="issue_url" title="URL" contentType=link linkLabel="open"/>
+</DataTable>
+
 ## Key Metrics
 
 ```sql kpis

--- a/dashboard/evidence/sources/fusion/issue_triage_health.sql
+++ b/dashboard/evidence/sources/fusion/issue_triage_health.sql
@@ -1,0 +1,1 @@
+SELECT * FROM issue_triage_health

--- a/dashboard/evidence/sources/fusion/oldest_untriaged.sql
+++ b/dashboard/evidence/sources/fusion/oldest_untriaged.sql
@@ -1,0 +1,1 @@
+SELECT * FROM oldest_untriaged

--- a/dashboard/ggsql/build.py
+++ b/dashboard/ggsql/build.py
@@ -57,7 +57,7 @@ class DuckDBConnReader:
         self._con.register(name, df)
 
 
-HEADER_RE = re.compile(r"^--\s*(title|blurb)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+HEADER_RE = re.compile(r"^--\s*(title|blurb|type)\s*:\s*(.+?)\s*$", re.IGNORECASE)
 
 
 @dataclass
@@ -66,7 +66,9 @@ class Chart:
     title: str
     blurb: str
     query: str
+    kind: str = "chart"  # "chart" | "kpi" | "table"
     spec_json: str = ""
+    data: pl.DataFrame | None = None
 
 
 def load_charts() -> list[Chart]:
@@ -84,10 +86,22 @@ def load_charts() -> list[Chart]:
                 meta[m.group(1).lower()] = m.group(2)
         title = meta.get("title") or path.stem
         blurb = meta.get("blurb", "")
-        charts.append(Chart(name=path.stem, title=title, blurb=blurb, query=text))
+        kind = meta.get("type", "chart").lower()
+        charts.append(Chart(name=path.stem, title=title, blurb=blurb, query=text, kind=kind))
     if not charts:
         raise SystemExit(f"no *.sql files found under {QUERIES_DIR}")
     return charts
+
+
+def _strip_header(query: str) -> str:
+    lines = []
+    in_header = True
+    for line in query.splitlines():
+        if in_header and (not line.strip() or line.startswith("--")):
+            continue
+        in_header = False
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def render(charts: list[Chart], db_path: str) -> None:
@@ -99,8 +113,11 @@ def render(charts: list[Chart], db_path: str) -> None:
     reader = DuckDBConnReader(db_path)
     writer = ggsql.VegaLiteWriter()
     for c in charts:
-        spec = ggsql.execute(c.query, reader)
-        c.spec_json = writer.render(spec)
+        if c.kind in ("kpi", "table"):
+            c.data = reader.execute_sql(_strip_header(c.query))
+        else:
+            spec = ggsql.execute(c.query, reader)
+            c.spec_json = writer.render(spec)
 
 
 HEAD = """<!doctype html>
@@ -119,28 +136,105 @@ HEAD = """<!doctype html>
   .blurb { color: #555; margin-bottom: 0.75rem; }
   .chart { width: 100%; height: 360px; }
   details pre { background: #f6f8fa; padding: 0.75rem; overflow-x: auto; font-size: 0.85rem; }
+  .kpi-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+             gap: 0.75rem; margin: 0.5rem 0 1rem; }
+  .kpi { border: 1px solid #e5e7eb; border-radius: 6px; padding: 0.75rem 1rem; background: #fafafa; }
+  .kpi .label { color: #666; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+  .kpi .value { font-size: 1.6rem; font-weight: 600; margin-top: 0.25rem; }
+  table.data { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  table.data th, table.data td { border-bottom: 1px solid #eee; padding: 0.4rem 0.6rem;
+                                  text-align: left; vertical-align: top; }
+  table.data th { background: #f6f8fa; font-weight: 600; }
+  table.data td.num { text-align: right; font-variant-numeric: tabular-nums; }
 </style>
 """
 
 
+def _humanize(col: str) -> str:
+    return col.replace("_", " ").replace("count", "").strip().title()
+
+
+def _kpi_html(c: Chart) -> str:
+    assert c.data is not None
+    row = c.data.row(0, named=True) if c.data.height else {}
+    cards = "\n".join(
+        f'<div class="kpi"><div class="label">{_humanize(k)}</div>'
+        f'<div class="value">{v if v is not None else "—"}</div></div>'
+        for k, v in row.items()
+    )
+    return f'<div class="kpi-row">{cards}</div>'
+
+
+def _table_html(c: Chart) -> str:
+    assert c.data is not None
+    cols = c.data.columns
+    numeric = {col for col, dt in zip(cols, c.data.dtypes) if dt.is_numeric()}
+    head = "".join(f"<th>{_humanize(col)}</th>" for col in cols)
+    rows_html = []
+    for row in c.data.iter_rows(named=True):
+        cells = []
+        for col in cols:
+            v = row[col]
+            cls = ' class="num"' if col in numeric else ""
+            if col == "issue_url" and v:
+                cell = f'<a href="{v}">link</a>'
+            elif col == "issue_number" and v is not None and row.get("issue_url"):
+                cell = f'<a href="{row["issue_url"]}">#{v}</a>'
+            else:
+                cell = "" if v is None else str(v)
+            cells.append(f"<td{cls}>{cell}</td>")
+        rows_html.append("<tr>" + "".join(cells) + "</tr>")
+    drop_url = "issue_url" in cols and "issue_number" in cols
+    if drop_url:
+        # `issue_number` already links; hide the redundant URL column.
+        idx = cols.index("issue_url")
+        head = "".join(f"<th>{_humanize(col)}</th>" for col in cols if col != "issue_url")
+        rows_html = []
+        for row in c.data.iter_rows(named=True):
+            cells = []
+            for col in cols:
+                if col == "issue_url":
+                    continue
+                v = row[col]
+                cls = ' class="num"' if col in numeric else ""
+                if col == "issue_number" and v is not None and row.get("issue_url"):
+                    cell = f'<a href="{row["issue_url"]}">#{v}</a>'
+                else:
+                    cell = "" if v is None else str(v)
+                cells.append(f"<td{cls}>{cell}</td>")
+            rows_html.append("<tr>" + "".join(cells) + "</tr>")
+    return (
+        '<table class="data"><thead><tr>' + head + "</tr></thead>"
+        "<tbody>" + "\n".join(rows_html) + "</tbody></table>"
+    )
+
+
 def to_html(charts: list[Chart], db_url: str) -> str:
+    # Render KPIs and tables first so the operational view sits above the charts.
+    order = {"kpi": 0, "table": 1, "chart": 2}
+    ordered = sorted(charts, key=lambda c: (order.get(c.kind, 2), c.name))
     body = [
         "<h1>ggsql spike</h1>",
         f'<div class="source">Rendered from <code>{db_url}</code> via ggsql → Vega-Lite.</div>',
     ]
     embeds: list[str] = []
-    for c in charts:
+    for c in ordered:
         body.append("<section>")
         body.append(f"<h2>{c.title}</h2>")
         if c.blurb:
             body.append(f'<div class="blurb">{c.blurb}</div>')
-        body.append(f'<div id="chart-{c.name}" class="chart"></div>')
+        if c.kind == "kpi":
+            body.append(_kpi_html(c))
+        elif c.kind == "table":
+            body.append(_table_html(c))
+        else:
+            body.append(f'<div id="chart-{c.name}" class="chart"></div>')
+            embeds.append(f"vegaEmbed('#chart-{c.name}', {c.spec_json}, {{actions: true}});")
         body.append(
             f"<details><summary>ggsql query ({c.name}.sql)</summary>"
             f"<pre>{c.query.strip()}</pre></details>"
         )
         body.append("</section>")
-        embeds.append(f"vegaEmbed('#chart-{c.name}', {c.spec_json}, {{actions: true}});")
     script = "<script>\n" + "\n".join(embeds) + "\n</script>"
     return HEAD + "\n".join(body) + "\n" + script
 

--- a/dashboard/ggsql/queries/08_triage_health.sql
+++ b/dashboard/ggsql/queries/08_triage_health.sql
@@ -1,0 +1,11 @@
+-- title: Triage Health
+-- blurb: Single-row operational counts across the open-issue triage taxonomy.
+-- type: kpi
+SELECT
+    slipped_through_count,
+    triage_queue_count,
+    hard_blocker_count,
+    stale_count,
+    needs_repro_count,
+    repro_verified_count
+FROM issue_triage_health

--- a/dashboard/ggsql/queries/09_oldest_untriaged.sql
+++ b/dashboard/ggsql/queries/09_oldest_untriaged.sql
@@ -1,0 +1,15 @@
+-- title: Oldest Untriaged Issues
+-- blurb: Top-25 open non-EPIC issues with zero triage signal — the daily action queue.
+-- type: table
+SELECT
+    issue_number,
+    title,
+    author_login,
+    issue_category,
+    reactions_total_count,
+    comments_total_count,
+    age_days,
+    days_since_activity,
+    issue_url
+FROM oldest_untriaged
+ORDER BY age_days DESC

--- a/dashboard/marimo/app.py
+++ b/dashboard/marimo/app.py
@@ -13,7 +13,7 @@ def _():
     import pandas as pd
     import os
 
-    return duckdb, go, mo, os, pd, px
+    return duckdb, mo, os, px
 
 
 @app.cell
@@ -29,11 +29,11 @@ def _(mo):
 def _(os):
     PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
     DB_PATH = os.environ.get("FUSION_DB") or ("md:fusion_issues" if os.environ.get("MOTHERDUCK_TOKEN") else os.path.join(PROJECT_ROOT, "data", "fusion_issues.duckdb"))
-    return (DB_PATH, PROJECT_ROOT)
+    return DB_PATH, PROJECT_ROOT
 
 
 @app.cell
-def _(DB_PATH, PROJECT_ROOT, duckdb):
+def _(DB_PATH, PROJECT_ROOT, duckdb, os):
     def query(sql):
         con = duckdb.connect(DB_PATH, read_only=True)
         if not DB_PATH.startswith("md:"):
@@ -46,7 +46,44 @@ def _(DB_PATH, PROJECT_ROOT, duckdb):
     return query, summary
 
 
-# ── Key Metrics ────────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Operational Triage
+    Daily action queue: bugs that slipped past triage, hard blockers, and the oldest zero-signal issues.
+    """)
+    return
+
+
+@app.cell
+def _(mo, query):
+    ops = query("SELECT * FROM issue_triage_health").iloc[0]
+    mo.hstack([
+        mo.stat(label="Slipped Through", value=str(int(ops['slipped_through_count'])), caption=f"{int(ops['slipped_through_bugs'])} bugs", bordered=True),
+        mo.stat(label="Triage Queue", value=str(int(ops['triage_queue_count'])), bordered=True),
+        mo.stat(label="Hard Blockers", value=str(int(ops['hard_blocker_count'])), caption=f"{int(ops['hard_blocker_unreleased'])} unreleased", bordered=True),
+        mo.stat(label="Needs Repro", value=str(int(ops['needs_repro_count'])), bordered=True),
+        mo.stat(label="Repro Verified", value=str(int(ops['repro_verified_count'])), bordered=True),
+        mo.stat(label="Stale (90d+)", value=str(int(ops['stale_count'])), bordered=True),
+        mo.stat(label="Total Open", value=str(int(ops['total_open'])), bordered=True),
+    ])
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ### Oldest Untriaged Issues
+    Top 25 open non-EPIC issues with zero triage signal, ordered by age.
+    """)
+    return
+
+
+@app.cell
+def _(mo, query):
+    untriaged = query("SELECT issue_number, title, age_days, issue_url FROM oldest_untriaged")
+    mo.ui.table(untriaged, selection=None, page_size=25)
+    return
 
 
 @app.cell
@@ -63,12 +100,11 @@ def _(mo, summary):
     return
 
 
-# ── Cumulative Issue Flow ──────────────────────────────────────────
-
-
 @app.cell
 def _(mo):
-    mo.md("## Cumulative Issue Flow")
+    mo.md("""
+    ## Cumulative Issue Flow
+    """)
     return
 
 
@@ -88,12 +124,11 @@ def _(px, query):
     return
 
 
-# ── Velocity & Response ────────────────────────────────────────────
-
-
 @app.cell
 def _(mo):
-    mo.md("## Velocity & Response")
+    mo.md("""
+    ## Velocity & Response
+    """)
     return
 
 
@@ -128,12 +163,11 @@ def _(px, query):
     return
 
 
-# ── Issue Distribution ─────────────────────────────────────────────
-
-
 @app.cell
 def _(mo):
-    mo.md("## Issue Distribution")
+    mo.md("""
+    ## Issue Distribution
+    """)
     return
 
 
@@ -169,12 +203,11 @@ def _(px, query):
     return
 
 
-# ── Triage Health ──────────────────────────────────────────────────
-
-
 @app.cell
 def _(mo):
-    mo.md("## Triage Health")
+    mo.md("""
+    ## Triage Health
+    """)
     return
 
 
@@ -190,12 +223,11 @@ def _(mo, query):
     return
 
 
-# ── Workload & Priorities ──────────────────────────────────────────
-
-
 @app.cell
 def _(mo):
-    mo.md("## Workload & Priorities")
+    mo.md("""
+    ## Workload & Priorities
+    """)
     return
 
 

--- a/dashboard/mdv/dashboard.mdv
+++ b/dashboard/mdv/dashboard.mdv
@@ -3,6 +3,8 @@ title: dbt-fusion Issue Health
 theme: minimal
 data:
   stats: ./data/stats.csv
+  triage_health: ./data/triage_health.csv
+  oldest_untriaged: ./data/oldest_untriaged.csv
   cumulative_flow: ./data/cumulative_flow.csv
   velocity: ./data/velocity.csv
   response: ./data/response.csv
@@ -23,6 +25,14 @@ styles:
 ::: note
 MDV keeps the page as Markdown with named CSV datasets. The rendered artifact is a self-contained HTML file with inline SVG charts.
 :::
+
+## Daily Triage Snapshot
+
+```stat data=triage_health
+```
+
+```table data=oldest_untriaged
+```
 
 ## Key Metrics
 

--- a/dashboard/mdv/generate_data.py
+++ b/dashboard/mdv/generate_data.py
@@ -74,11 +74,41 @@ def write_csv(filename: str, rows: list[dict[str, Any]], fieldnames: list[str] |
     print(f"  wrote {path} ({len(rows)} records)")
 
 
+def build_triage_stats(triage: dict[str, Any]) -> list[dict[str, str]]:
+    return [
+        {"label": "Slipped through (no signal)", "value": fmt_int(triage["slipped_through_count"]), "delta": ""},
+        {"label": "In triage queue", "value": fmt_int(triage["triage_queue_count"]), "delta": ""},
+        {"label": "Hard blockers", "value": fmt_int(triage["hard_blocker_count"]), "delta": ""},
+        {"label": "Needs repro", "value": fmt_int(triage["needs_repro_count"]), "delta": ""},
+        {"label": "Repro verified", "value": fmt_int(triage["repro_verified_count"]), "delta": ""},
+        {"label": "Stale", "value": fmt_int(triage["stale_count"]), "delta": ""},
+    ]
+
+
 def main() -> None:
     con = get_connection()
 
     summary = query(con, "SELECT * FROM summary_kpis")[0]
     write_csv("stats.csv", build_stats(summary), ["label", "value", "delta"])
+
+    triage = query(con, "SELECT * FROM issue_triage_health")[0]
+    write_csv("triage_health.csv", build_triage_stats(triage), ["label", "value", "delta"])
+
+    write_csv(
+        "oldest_untriaged.csv",
+        query(
+            con,
+            """
+            select
+                issue_number,
+                title,
+                age_days,
+                issue_url
+            from oldest_untriaged
+            order by age_days desc
+            """,
+        ),
+    )
 
     write_csv(
         "cumulative_flow.csv",

--- a/dashboard/mviz/dashboard.md
+++ b/dashboard/mviz/dashboard.md
@@ -8,6 +8,32 @@ continuous: true
 
 Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)
 
+## Daily Triage Queue
+
+```big_value size=[3,2] file=data/kpi_slipped_through.json
+```
+```big_value size=[3,2] file=data/kpi_triage_queue.json
+```
+```big_value size=[3,2] file=data/kpi_hard_blocker.json
+```
+```big_value size=[3,2] file=data/kpi_op_stale.json
+```
+```big_value size=[2,2] file=data/kpi_needs_repro.json
+```
+```big_value size=[2,2] file=data/kpi_repro_verified.json
+```
+
+```table size=[16,8] file=data/oldest_untriaged.json
+{
+  "title": "Oldest Untriaged Issues — Zero-Signal Action Queue",
+  "columns": [
+    {"id": "issue_number", "title": "#", "bold": true},
+    {"id": "title", "title": "Title"},
+    {"id": "age_days", "title": "Age (days)", "bold": true}
+  ]
+}
+```
+
 ## Key Metrics
 
 ```big_value size=[3,2] file=data/kpi_net_flow.json

--- a/dashboard/mviz/generate_data.py
+++ b/dashboard/mviz/generate_data.py
@@ -105,6 +105,17 @@ def main():
     # -- Assignee workload --
     write_json("assignee_workload.json", query(con, "SELECT * FROM assignee_workload"))
 
+    # -- Operational triage (daily) --
+    op_triage = query(con, "SELECT * FROM issue_triage_health")[0]
+    write_json("kpi_slipped_through.json", {"value": op_triage["slipped_through_count"], "label": "Slipped Through (no signal)"})
+    write_json("kpi_triage_queue.json", {"value": op_triage["triage_queue_count"], "label": "Triage Queue"})
+    write_json("kpi_hard_blocker.json", {"value": op_triage["hard_blocker_count"], "label": "Hard Blockers"})
+    write_json("kpi_op_stale.json", {"value": op_triage["stale_count"], "label": "Stale (90d+)"})
+    write_json("kpi_needs_repro.json", {"value": op_triage["needs_repro_count"], "label": "Needs Repro"})
+    write_json("kpi_repro_verified.json", {"value": op_triage["repro_verified_count"], "label": "Repro Verified"})
+
+    write_json("oldest_untriaged.json", query(con, "SELECT issue_number, title, age_days, issue_url FROM oldest_untriaged"))
+
     # -- Triage health --
     triage = query(con, "SELECT * FROM triage_health")[0]
     write_json("kpi_triage_labeled.json", {"value": pct0_value(triage["pct_labeled"]), "label": "% Labeled", "format": "pct0"})

--- a/dashboard/observable/src/data/_loader.sh
+++ b/dashboard/observable/src/data/_loader.sh
@@ -30,6 +30,8 @@ if not DB_PATH.startswith("md:"):
 SQL_BY_NAME = {
     "summary": "SELECT * FROM summary_kpis",
     "triage": "SELECT * FROM triage_health",
+    "triage_health": "SELECT * FROM issue_triage_health",
+    "oldest_untriaged": "SELECT * FROM oldest_untriaged",
     "cumulative_flow": "SELECT * FROM cumulative_flow ORDER BY week",
     "response_pctiles": "SELECT * FROM response_pctiles ORDER BY week",
     "close_by_label": "SELECT * FROM close_by_label ORDER BY median_days_to_close DESC",

--- a/dashboard/observable/src/data/oldest_untriaged.json.sh
+++ b/dashboard/observable/src/data/oldest_untriaged.json.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$SCRIPT_DIR/_loader.sh" oldest_untriaged

--- a/dashboard/observable/src/data/triage_health.json.sh
+++ b/dashboard/observable/src/data/triage_health.json.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$SCRIPT_DIR/_loader.sh" triage_health --first-row

--- a/dashboard/observable/src/index.md
+++ b/dashboard/observable/src/index.md
@@ -16,7 +16,64 @@ const closeByLabel = await FileAttachment("data/close_by_label.json").json();
 const triage = await FileAttachment("data/triage.json").json();
 const assigneeWorkload = await FileAttachment("data/assignee_workload.json").json();
 const communityPriorities = await FileAttachment("data/community_priorities.json").json();
+const triageHealth = await FileAttachment("data/triage_health.json").json();
+const oldestUntriaged = await FileAttachment("data/oldest_untriaged.json").json();
 ```
+
+## Daily triage
+
+<div style="display:grid;grid-template-columns:repeat(6,1fr);gap:12px;margin:20px 0">
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#f38ba8">${triageHealth.slipped_through_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Slipped through</div>
+</div>
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#fab387">${triageHealth.triage_queue_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Triage queue</div>
+</div>
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#eba0ac">${triageHealth.hard_blocker_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Hard blockers</div>
+</div>
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#cba6f7">${triageHealth.stale_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Stale</div>
+</div>
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#89dceb">${triageHealth.needs_repro_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Needs repro</div>
+</div>
+
+<div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
+  <div style="font-size:28px;font-weight:bold;color:#a6e3a1">${triageHealth.repro_verified_count}</div>
+  <div style="color:#a6adc8;font-size:13px">Repro verified</div>
+</div>
+
+</div>
+
+### Oldest untriaged issues
+
+<table style="width:100%;border-collapse:collapse;margin:12px 0">
+  <thead>
+    <tr style="border-bottom:1px solid #313244;color:#a6adc8;text-align:left">
+      <th style="padding:8px">Issue</th>
+      <th style="padding:8px">Title</th>
+      <th style="padding:8px;text-align:right">Age (days)</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${oldestUntriaged.map(d => html`<tr style="border-bottom:1px solid #313244">
+      <td style="padding:8px"><a href="${d.issue_url}" style="color:#89b4fa">#${d.issue_number}</a></td>
+      <td style="padding:8px">${d.title}</td>
+      <td style="padding:8px;text-align:right;color:#f38ba8;font-weight:bold">${d.age_days}</td>
+    </tr>`)}
+  </tbody>
+</table>
 
 ## Key Metrics
 

--- a/dashboard/prefab/app.py
+++ b/dashboard/prefab/app.py
@@ -44,6 +44,12 @@ def query(sql: str) -> list[dict]:
     return result.to_dict("records")
 
 
+# ── Operational triage KPIs ────────────────────────────────────────
+
+triage_health = query("SELECT * FROM issue_triage_health")[0]
+triage_lag = query("SELECT * FROM issue_triage_lag")[0]
+oldest_untriaged = query("SELECT * FROM oldest_untriaged")
+
 # ── Summary cards ──────────────────────────────────────────────────
 
 summary_cards = query("SELECT * FROM summary_kpis")[0]
@@ -130,6 +136,97 @@ leaderboard = query("SELECT * FROM leaderboard")
 with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
     H2("dbt-fusion Issue Health")
     Muted("Actionable metrics for dbt-labs/dbt-fusion (excludes EPICs)")
+
+    # ── Daily operational KPIs ─────────────────────────────────────
+    H3("Daily triage", css_class="mt-6")
+    Muted("Open the dashboard, scan this row, act on the table below.")
+
+    with Row(gap=3, css_class="mt-3"):
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Slipped through")
+            with CardContent():
+                H3(str(triage_health["slipped_through_count"]))
+                Muted(f"{triage_health['slipped_through_bugs']} bugs · zero triage label")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Triage queue")
+            with CardContent():
+                H3(str(triage_health["triage_queue_count"]))
+                Muted("Awaiting maintainer decision")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Hard blockers")
+            with CardContent():
+                H3(str(triage_health["hard_blocker_count"]))
+                Muted(f"{triage_health['hard_blocker_unreleased']} unreleased")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Stale (90d+)")
+            with CardContent():
+                H3(str(triage_health["stale_count"]))
+                Muted("Cleanup candidates")
+
+    with Row(gap=3, css_class="mt-3"):
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Needs repro")
+            with CardContent():
+                H3(str(triage_health["needs_repro_count"]))
+                Muted("Awaiting reproduction")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Ready for engineer")
+            with CardContent():
+                H3(str(triage_health["repro_verified_count"]))
+                Muted("has-repro / repro/verified")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Median triage lag, bugs")
+                Muted("7-day rolling, proxy")
+            with CardContent():
+                lag = triage_lag["median_days_to_first_triage_bugs"]
+                H3(f"{lag} d" if lag else "—")
+                Muted("Created → first maintainer reply")
+
+        with Card(css_class="flex-1"):
+            with CardHeader():
+                CardTitle("Median repro lag")
+                Muted("7-day rolling, proxy")
+            with CardContent():
+                lag = triage_lag["median_days_triage_to_repro_verified"]
+                H3(f"{lag} d" if lag else "—")
+                Muted("Triage → repro/verified")
+
+    # ── Oldest untriaged action queue ──────────────────────────────
+    with Card(css_class="mt-6"):
+        with CardHeader():
+            CardTitle("Oldest untriaged issues")
+            Muted(f"Top {len(oldest_untriaged)} open issues with zero triage signal — work this list")
+        with CardContent():
+            DataTable(
+                data=oldest_untriaged,
+                columns=[
+                    DataTableColumn(key="issue_number", header="#", sortable=True),
+                    DataTableColumn(key="title", header="Title"),
+                    DataTableColumn(key="issue_category", header="Type", sortable=True),
+                    DataTableColumn(key="age_days", header="Age (days)", sortable=True),
+                    DataTableColumn(key="days_since_activity", header="Idle (days)", sortable=True),
+                    DataTableColumn(key="reactions_total_count", header="Reactions", sortable=True),
+                    DataTableColumn(key="comments_total_count", header="Comments", sortable=True),
+                    DataTableColumn(key="author_login", header="Author"),
+                ],
+                search=True,
+                pagination=15,
+            )
+
+    Separator(css_class="my-8")
+    H3("Trends and context")
 
     # ── Summary cards ──────────────────────────────────────────────
     with Row(gap=3, css_class="mt-6"):

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -303,6 +303,34 @@ models:
         tests:
           - not_null
 
+  - name: issue_triage_health
+    description: Single-row counts of open non-EPIC issues across the triage taxonomy (slipped, queue, needs-repro, repro-verified, awaiting-release, hard-blocker, stale)
+    columns:
+      - name: total_open
+        tests:
+          - not_null
+      - name: slipped_through_count
+        tests:
+          - not_null
+      - name: triage_queue_count
+        tests:
+          - not_null
+      - name: needs_repro_count
+        tests:
+          - not_null
+      - name: repro_verified_count
+        tests:
+          - not_null
+      - name: awaiting_release_count
+        tests:
+          - not_null
+      - name: hard_blocker_count
+        tests:
+          - not_null
+      - name: stale_count
+        tests:
+          - not_null
+
   - name: issue_triage_lag
     description: >
       Per-issue triage-lag metrics built from real LABELED_EVENT timestamps:
@@ -316,4 +344,15 @@ models:
       - name: issue_number
         tests:
           - unique
+          - not_null
+
+  - name: oldest_untriaged
+    description: Top 25 oldest open non-EPIC issues with zero triage signal — the daily action queue
+    columns:
+      - name: issue_number
+        tests:
+          - not_null
+          - unique
+      - name: age_days
+        tests:
           - not_null

--- a/transform/models/dashboard/issue_triage_health.sql
+++ b/transform/models/dashboard/issue_triage_health.sql
@@ -1,0 +1,50 @@
+{# Single-row counts of open non-EPIC issues across the triage taxonomy. #}
+
+with issue_triage as (
+    select
+        i.issue_dlt_id,
+        i.state,
+        i.issue_category,
+        i.updated_at,
+        max(case when l.label_name = 'triage' then 1 else 0 end) as has_triage,
+        max(case when l.label_name = 'needs-repro' then 1 else 0 end) as has_needs_repro,
+        max(case when l.label_name in ('has-repro', 'repro/verified') then 1 else 0 end) as has_repro_verified,
+        max(case when l.label_name = 'hard-blocker' then 1 else 0 end) as has_hard_blocker,
+        max(case when l.label_name = 'release/awaiting-release' then 1 else 0 end) as has_awaiting_release,
+        max(case when l.label_name = 'cleanup/stale' then 1 else 0 end) as has_stale_label
+    from {{ ref('fct_issues') }} i
+    left join {{ ref('stg_issue_labels') }} l using (issue_dlt_id)
+    where i.state = 'OPEN' and i.issue_category != 'epic'
+    group by 1, 2, 3, 4
+),
+
+classified as (
+    select
+        *,
+        case
+            when has_awaiting_release = 1 then 'awaiting_release'
+            when has_repro_verified = 1 then 'repro_verified'
+            when has_needs_repro = 1 then 'needs_repro'
+            when has_triage = 1 then 'triage_queue'
+            else 'no_signal'
+        end as triage_state,
+        case
+            when has_stale_label = 1 then 1
+            when updated_at < current_date - interval '90 days' then 1
+            else 0
+        end as is_stale
+    from issue_triage
+)
+
+select
+    count(*) as total_open,
+    count(case when triage_state = 'no_signal' then 1 end) as slipped_through_count,
+    count(case when triage_state = 'triage_queue' then 1 end) as triage_queue_count,
+    count(case when triage_state = 'needs_repro' then 1 end) as needs_repro_count,
+    count(case when triage_state = 'repro_verified' then 1 end) as repro_verified_count,
+    count(case when triage_state = 'awaiting_release' then 1 end) as awaiting_release_count,
+    count(case when has_hard_blocker = 1 then 1 end) as hard_blocker_count,
+    count(case when is_stale = 1 then 1 end) as stale_count,
+    count(case when triage_state = 'no_signal' and issue_category = 'bug' then 1 end) as slipped_through_bugs,
+    count(case when has_hard_blocker = 1 and has_awaiting_release = 0 then 1 end) as hard_blocker_unreleased
+from classified

--- a/transform/models/dashboard/issue_triage_lag.sql
+++ b/transform/models/dashboard/issue_triage_lag.sql
@@ -1,78 +1,49 @@
-{# Triage-lag metrics derived from real LABELED_EVENT timestamps.
-   Replaces earlier comment-proxy approximations that used
-   first non-author comment / updated_at as stand-ins. #}
+{#
+  Rolling 7-day medians for triage SLAs.
 
-with issues as (
+  The raw GraphQL extract captures only the current label set, not label
+  timeline events, so we approximate transition timestamps:
+    - "first triage" ≈ first non-author comment (hours_to_first_response).
+      A maintainer's first reply is the de-facto triage moment.
+    - "triage → repro_verified" is approximated for bugs that currently carry
+      the has-repro / repro/verified label, using updated_at - first_response_at
+      as the elapsed verification time. This is a lower bound: updated_at
+      shifts on any subsequent activity.
+#}
+
+with bugs as (
     select
-        issue_dlt_id,
-        issue_number,
-        issue_url,
-        title,
-        state,
-        author_login,
-        created_at as issue_created_at,
-        closed_at
-    from {{ ref('stg_issues') }}
+        i.issue_dlt_id,
+        i.created_at,
+        i.first_response_at,
+        i.updated_at,
+        i.hours_to_first_response,
+        max(case when l.label_name in ('has-repro', 'repro/verified') then 1 else 0 end) as has_repro_verified
+    from {{ ref('fct_issues') }} i
+    left join {{ ref('stg_issue_labels') }} l using (issue_dlt_id)
+    where i.issue_category = 'bug'
+    group by 1, 2, 3, 4, 5
 ),
 
-label_events as (
-    select
-        issue_dlt_id,
-        label_name,
-        event_at
-    from {{ ref('stg_issue_label_events') }}
-    where event_type = 'LabeledEvent'
+triage_lag as (
+    select median(hours_to_first_response) as median_hours_to_first_triage_bugs
+    from bugs
+    where created_at >= current_date - interval '7 days'
+      and hours_to_first_response is not null
 ),
 
-first_triage_event as (
-    -- Earliest application of any label that signals an issue has entered
-    -- the triage queue or been categorised as a bug.
+repro_lag as (
     select
-        issue_dlt_id,
-        min(event_at) as first_triage_at
-    from label_events
-    where label_name in ('triage', 'needs-repro', 'bug')
-    group by issue_dlt_id
-),
-
-first_repro_event as (
-    -- Earliest application of any label that signals the bug has been
-    -- reproduced/verified by a maintainer.
-    select
-        issue_dlt_id,
-        min(event_at) as first_repro_at
-    from label_events
-    where label_name in ('repro/verified', 'has-repro', 'has_repro')
-    group by issue_dlt_id
+        median(date_diff('hour', first_response_at, updated_at)) as median_hours_triage_to_repro_verified
+    from bugs
+    where has_repro_verified = 1
+      and first_response_at is not null
+      and updated_at >= current_date - interval '7 days'
 )
 
 select
-    i.issue_dlt_id,
-    i.issue_number,
-    i.issue_url,
-    i.title,
-    i.state,
-    i.author_login,
-    i.issue_created_at,
-    i.closed_at,
-    ft.first_triage_at,
-    fr.first_repro_at,
-
-    case
-        when ft.first_triage_at is not null
-            then date_diff('hour', i.issue_created_at, ft.first_triage_at)
-    end as hours_to_first_triage,
-
-    case
-        when ft.first_triage_at is not null and fr.first_repro_at is not null
-            then date_diff('hour', ft.first_triage_at, fr.first_repro_at)
-    end as hours_triage_to_repro,
-
-    case
-        when fr.first_repro_at is not null
-            then date_diff('hour', i.issue_created_at, fr.first_repro_at)
-    end as hours_to_first_repro
-
-from issues i
-left join first_triage_event ft on i.issue_dlt_id = ft.issue_dlt_id
-left join first_repro_event fr on i.issue_dlt_id = fr.issue_dlt_id
+    round(coalesce(triage_lag.median_hours_to_first_triage_bugs, 0) / 24.0, 1) as median_days_to_first_triage_bugs,
+    round(coalesce(repro_lag.median_hours_triage_to_repro_verified, 0) / 24.0, 1) as median_days_triage_to_repro_verified,
+    triage_lag.median_hours_to_first_triage_bugs as median_hours_to_first_triage_bugs,
+    repro_lag.median_hours_triage_to_repro_verified as median_hours_triage_to_repro_verified
+from triage_lag cross join repro_lag

--- a/transform/models/dashboard/oldest_untriaged.sql
+++ b/transform/models/dashboard/oldest_untriaged.sql
@@ -1,0 +1,30 @@
+{# Oldest open non-EPIC issues with zero triage signal — the daily action queue. #}
+
+with issue_labels_agg as (
+    select
+        issue_dlt_id,
+        max(case when label_name in (
+            'triage', 'needs-repro', 'has-repro', 'repro/verified',
+            'hard-blocker', 'release/awaiting-release', 'cleanup/stale'
+        ) then 1 else 0 end) as has_triage_signal
+    from {{ ref('stg_issue_labels') }}
+    group by 1
+)
+
+select
+    i.issue_number,
+    i.title,
+    i.author_login,
+    i.issue_category,
+    i.reactions_total_count,
+    i.comments_total_count,
+    i.issue_url,
+    date_diff('day', i.created_at, current_date) as age_days,
+    date_diff('day', i.updated_at, current_date) as days_since_activity
+from {{ ref('fct_issues') }} i
+left join issue_labels_agg l using (issue_dlt_id)
+where i.state = 'OPEN'
+  and i.issue_category != 'epic'
+  and coalesce(l.has_triage_signal, 0) = 0
+order by i.created_at asc
+limit 25


### PR DESCRIPTION
New dbt models (issue_triage_health, issue_triage_lag, oldest_untriaged) + Prefab 'Daily triage' section with 8 KPI cards and oldest-untriaged action table. All metric logic in dbt. Note: lag model uses comment proxies — superseded by the label-timeline PR.