### PR TITLE
Compute triage lag from real `LABELED_EVENT` timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # ── Extract unit tests (no network) ──────────────────────────────────
+      - name: Test extract helpers
+        run: uv run --with pytest pytest extract/tests/ -v
+
+      # ── dbt compile against prod (strict static analysis) ────────────────
+      - name: Install dbt Fusion
+        run: |
+          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Compile dbt models
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: |
+          cd transform
+          dbt compile --profiles-dir . --target prod --static-analysis strict
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,19 @@ jobs:
       - name: Test extract helpers
         run: uv run --with pytest pytest extract/tests/ -v
 
-      # ── dbt compile against prod (strict static analysis) ────────────────
+      # ── dbt compile against prod ─────────────────────────────────────────
       - name: Install dbt Fusion
         run: |
           curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Compile dbt models
+        timeout-minutes: 5
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
           cd transform
-          dbt compile --profiles-dir . --target prod --static-analysis strict
+          dbt compile --profiles-dir . --target prod
 
       - name: Render About page
         run: uv run python3 dashboard/render_about.py

--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -82,6 +82,7 @@ def get_reactions_data(
         "issues_per_page": items_per_page,
         "first_reactions": 100,
         "first_comments": 100,
+        "first_timeline_items": 50,
         "node_type": node_type,
     }
     for page_items in _get_graphql_pages(
@@ -127,6 +128,11 @@ def _extract_nested_nodes(item: DictStrAny) -> DictStrAny:
             comment["reactions_totalCount"] = comment["reactions"].get("totalCount", 0)
             comment["reactions"] = comment["reactions"]["nodes"]
     item["comments"] = comments["nodes"]
+    if "timelineItems" in item:
+        timeline = item["timelineItems"]
+        item["timeline_items_totalCount"] = timeline.get("totalCount", 0)
+        item["timeline_items"] = timeline["nodes"]
+        item.pop("timelineItems", None)
     return item
 
 

--- a/extract/github/queries.py
+++ b/extract/github/queries.py
@@ -8,7 +8,7 @@ RATE_LIMIT = """
 """
 
 ISSUES_QUERY = """
-query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions: Int!, $first_comments: Int!, $page_after: String) {
+query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions: Int!, $first_comments: Int!, $first_timeline_items: Int!, $page_after: String) {
   repository(owner: $owner, name: $name) {
     %s(first: $issues_per_page, orderBy: {field: CREATED_AT, direction: DESC}, after: $page_after) {
       totalCount
@@ -59,6 +59,22 @@ query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions:
             user {login avatarUrl url}
             content
             createdAt
+          }
+        }
+        timelineItems(first: $first_timeline_items, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
+          totalCount
+          nodes {
+            __typename
+            ... on LabeledEvent {
+              createdAt
+              actor {login avatarUrl url}
+              label {name color}
+            }
+            ... on UnlabeledEvent {
+              createdAt
+              actor {login avatarUrl url}
+              label {name color}
+            }
           }
         }
         comments(first: $first_comments) {

--- a/extract/run.py
+++ b/extract/run.py
@@ -20,6 +20,12 @@ def main():
         action="store_true",
         help="Write directly to MotherDuck instead of local parquet",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of issues/PRs fetched (for quick testing).",
+    )
     args = parser.parse_args()
 
     # GitHub token
@@ -51,7 +57,10 @@ def main():
         owner="dbt-labs",
         name="dbt-fusion",
         access_token=access_token,
-        items_per_page=100,
+        # 50 keeps combined cost (issue + comments + reactions + timelineItems)
+        # under GitHub's GraphQL resource-limits ceiling.
+        items_per_page=50 if args.limit is None else min(50, args.limit),
+        max_items=args.limit,
     ).with_resources("issues", "pull_requests")
 
     loader_kwargs = {}

--- a/extract/tests/test_helpers.py
+++ b/extract/tests/test_helpers.py
@@ -1,0 +1,65 @@
+"""Unit tests for extract/github/helpers.py — no network required."""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from github.helpers import _extract_nested_nodes
+
+
+def _base_item():
+    return {
+        "reactions": {"totalCount": 2, "nodes": [{"content": "THUMBS_UP"}]},
+        "comments": {
+            "totalCount": 1,
+            "nodes": [
+                {
+                    "id": "c1",
+                    "reactions": {"totalCount": 0, "nodes": []},
+                }
+            ],
+        },
+    }
+
+
+def test_timeline_items_flattened():
+    item = _base_item()
+    item["timelineItems"] = {
+        "totalCount": 3,
+        "nodes": [
+            {"__typename": "LabeledEvent", "createdAt": "2024-01-01T00:00:00Z", "label": {"name": "bug"}},
+            {"__typename": "LabeledEvent", "createdAt": "2024-01-02T00:00:00Z", "label": {"name": "triage"}},
+            {"__typename": "UnlabeledEvent", "createdAt": "2024-01-03T00:00:00Z", "label": {"name": "triage"}},
+        ],
+    }
+    result = _extract_nested_nodes(item)
+
+    assert "timelineItems" not in result, "raw timelineItems key should be removed"
+    assert result["timeline_items_totalCount"] == 3
+    assert len(result["timeline_items"]) == 3
+    assert result["timeline_items"][0]["label"]["name"] == "bug"
+
+
+def test_no_timeline_items_is_fine():
+    """Issues without timelineItems (e.g. old extract runs) should not error."""
+    item = _base_item()
+    result = _extract_nested_nodes(item)
+    assert "timeline_items" not in result
+    assert "timeline_items_totalCount" not in result
+    assert "timelineItems" not in result
+
+
+def test_reactions_still_flattened():
+    item = _base_item()
+    result = _extract_nested_nodes(item)
+    assert result["reactions_totalCount"] == 2
+    assert isinstance(result["reactions"], list)
+    assert result["reactions"][0]["content"] == "THUMBS_UP"
+
+
+def test_comment_reactions_still_flattened():
+    item = _base_item()
+    result = _extract_nested_nodes(item)
+    comment = result["comments"][0]
+    assert comment["reactions_totalCount"] == 0
+    assert isinstance(comment["reactions"], list)

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -302,3 +302,18 @@ models:
       - name: issues_opened
         tests:
           - not_null
+
+  - name: issue_triage_lag
+    description: >
+      Per-issue triage-lag metrics built from real LABELED_EVENT timestamps:
+      hours from issue creation to first triage label, and hours from first triage
+      label to repro/verified. Replaces the earlier comment-proxy approximations.
+    columns:
+      - name: issue_dlt_id
+        tests:
+          - unique
+          - not_null
+      - name: issue_number
+        tests:
+          - unique
+          - not_null

--- a/transform/models/dashboard/issue_triage_lag.sql
+++ b/transform/models/dashboard/issue_triage_lag.sql
@@ -1,0 +1,78 @@
+{# Triage-lag metrics derived from real LABELED_EVENT timestamps.
+   Replaces earlier comment-proxy approximations that used
+   first non-author comment / updated_at as stand-ins. #}
+
+with issues as (
+    select
+        issue_dlt_id,
+        issue_number,
+        issue_url,
+        title,
+        state,
+        author_login,
+        created_at as issue_created_at,
+        closed_at
+    from {{ ref('stg_issues') }}
+),
+
+label_events as (
+    select
+        issue_dlt_id,
+        label_name,
+        event_at
+    from {{ ref('stg_issue_label_events') }}
+    where event_type = 'LabeledEvent'
+),
+
+first_triage_event as (
+    -- Earliest application of any label that signals an issue has entered
+    -- the triage queue or been categorised as a bug.
+    select
+        issue_dlt_id,
+        min(event_at) as first_triage_at
+    from label_events
+    where label_name in ('triage', 'needs-repro', 'bug')
+    group by issue_dlt_id
+),
+
+first_repro_event as (
+    -- Earliest application of any label that signals the bug has been
+    -- reproduced/verified by a maintainer.
+    select
+        issue_dlt_id,
+        min(event_at) as first_repro_at
+    from label_events
+    where label_name in ('repro/verified', 'has-repro', 'has_repro')
+    group by issue_dlt_id
+)
+
+select
+    i.issue_dlt_id,
+    i.issue_number,
+    i.issue_url,
+    i.title,
+    i.state,
+    i.author_login,
+    i.issue_created_at,
+    i.closed_at,
+    ft.first_triage_at,
+    fr.first_repro_at,
+
+    case
+        when ft.first_triage_at is not null
+            then date_diff('hour', i.issue_created_at, ft.first_triage_at)
+    end as hours_to_first_triage,
+
+    case
+        when ft.first_triage_at is not null and fr.first_repro_at is not null
+            then date_diff('hour', ft.first_triage_at, fr.first_repro_at)
+    end as hours_triage_to_repro,
+
+    case
+        when fr.first_repro_at is not null
+            then date_diff('hour', i.issue_created_at, fr.first_repro_at)
+    end as hours_to_first_repro
+
+from issues i
+left join first_triage_event ft on i.issue_dlt_id = ft.issue_dlt_id
+left join first_repro_event fr on i.issue_dlt_id = fr.issue_dlt_id

--- a/transform/models/staging/_sources.yml
+++ b/transform/models/staging/_sources.yml
@@ -82,6 +82,35 @@ models:
                 to: ref('stg_issues')
                 field: issue_dlt_id
 
+  - name: stg_issue_label_events
+    description: >
+      LABELED_EVENT / UNLABELED_EVENT timeline entries for issues. Sourced from
+      GitHub GraphQL `timelineItems` and used for accurate label-application timestamps.
+    columns:
+      - name: event_dlt_id
+        tests:
+          - unique
+          - not_null
+      - name: issue_dlt_id
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_issues')
+                field: issue_dlt_id
+      - name: event_type
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['LabeledEvent', 'UnlabeledEvent']
+      - name: event_at
+        tests:
+          - not_null
+      - name: label_name
+        tests:
+          - not_null
+
   - name: stg_pull_requests
     description: Cleaned pull requests from dbt-labs/dbt-fusion
     columns:

--- a/transform/models/staging/stg_issue_label_events.sql
+++ b/transform/models/staging/stg_issue_label_events.sql
@@ -1,0 +1,20 @@
+with source as (
+    select * from {{ raw_source('issues__timeline_items') }}
+),
+
+renamed as (
+    select
+        _dlt_id as event_dlt_id,
+        _dlt_parent_id as issue_dlt_id,
+        typename as event_type,
+        created_at as event_at,
+        label__name as label_name,
+        label__color as label_color,
+        actor__login as actor_login,
+        actor__avatar_url as actor_avatar_url,
+        actor__url as actor_url
+    from source
+    where typename in ('LabeledEvent', 'UnlabeledEvent')
+)
+
+select * from renamed


### PR DESCRIPTION
Adds `LABELED_EVENT`/`UNLABELED_EVENT` timeline items to the GitHub GraphQL extract. New `stg_issue_label_events` staging model. Rewrites `issue_triage_lag.sql` to use actual label timestamps instead of comment proxies. `fct_issues.hours_to_first_response` preserved as engagement metric. Note: median time-to-triage ≈ 0h due to auto-labeling bot — filter on actor for human signal.