### PR TITLE
Hotfix post-#46: dbt schema dup, DAC row span, framework deploy isolation, ggsql week DATE cast

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -69,33 +69,43 @@ jobs:
         run: uv run python3 dashboard/shaper/build.py
 
       - name: Export Prefab dashboards
+        id: prefab
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
           for f in dashboard/prefab/app*.py; do
             name=$(basename "$f" .py)
-            uv run prefab export "$f" -o "dashboard/prefab/${name}.html" || true
+            uv run prefab export "$f" -o "dashboard/prefab/${name}.html"
           done
 
       - name: Build npm dashboards
+        id: npm
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           EVIDENCE_BASE_PATH: /evidence/build
         run: npm run build:npm-dashboards
 
       - name: Build MDV dashboard
+        id: mdv
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           MDV_CACHE_DIR: ${{ runner.temp }}/fusion-mdv-cache/mdv-${{ env.MDV_SHA }}
         run: bash dashboard/mdv/build.sh
 
       - name: Build ggsql dashboard
+        id: ggsql
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           FUSION_DB: md:fusion_issues
         run: uv run dashboard/ggsql/build.py
 
       - name: Export Marimo dashboard
+        id: marimo
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o dashboard/marimo.html
@@ -104,6 +114,8 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Render Quarto dashboard
+        id: quarto
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           QUARTO_PYTHON: ${{ github.workspace }}/.venv/bin/python3
@@ -112,6 +124,8 @@ jobs:
           quarto render index.qmd
 
       - name: Build DAC dashboard
+        id: dac
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           DAC_ENVIRONMENT: prod
@@ -120,13 +134,50 @@ jobs:
           uv run python3 dashboard/dac/render.py
           ! grep -q 'bruin query failed' dashboard/dac/build/index.html
 
+      # Upload whatever built successfully; deploy job runs regardless of framework failures.
       - name: Upload Pages artifact
+        if: always()
         uses: actions/upload-pages-artifact@v5
         with:
           path: dashboard/
 
+      # Write a plain-English summary and fail the job if any framework broke,
+      # so GitHub's notification email links directly to the explanation.
+      - name: Framework build summary
+        if: always()
+        run: |
+          {
+            echo "## Framework build results"
+            echo ""
+            echo "| Framework | Result |"
+            echo "|-----------|--------|"
+            icon() { case $1 in success) echo "✅";; failure) echo "❌ **failed**";; *) echo "⚠️ $1";; esac; }
+            echo "| Prefab | $(icon '${{ steps.prefab.outcome }}') |"
+            echo "| npm (Observable + Evidence) | $(icon '${{ steps.npm.outcome }}') |"
+            echo "| MDV | $(icon '${{ steps.mdv.outcome }}') |"
+            echo "| ggsql | $(icon '${{ steps.ggsql.outcome }}') |"
+            echo "| Marimo | $(icon '${{ steps.marimo.outcome }}') |"
+            echo "| Quarto | $(icon '${{ steps.quarto.outcome }}') |"
+            echo "| DAC | $(icon '${{ steps.dac.outcome }}') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Fail the job so GitHub sends a notification email, but only after
+          # the artifact has already been uploaded above.
+          for outcome in \
+            '${{ steps.prefab.outcome }}' \
+            '${{ steps.npm.outcome }}' \
+            '${{ steps.mdv.outcome }}' \
+            '${{ steps.ggsql.outcome }}' \
+            '${{ steps.marimo.outcome }}' \
+            '${{ steps.quarto.outcome }}' \
+            '${{ steps.dac.outcome }}'; do
+            [ "$outcome" = "failure" ] && { echo "One or more framework builds failed — see table above." >&2; exit 1; }
+          done
+
+  # Runs even when the build job ends red (framework failure), as long as the
+  # artifact was uploaded. Skipped only if the build job was cancelled entirely.
   deploy:
     needs: build
+    if: always() && needs.build.result != 'cancelled'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -170,7 +170,10 @@ jobs:
             '${{ steps.marimo.outcome }}' \
             '${{ steps.quarto.outcome }}' \
             '${{ steps.dac.outcome }}'; do
-            [ "$outcome" = "failure" ] && { echo "One or more framework builds failed — see table above." >&2; exit 1; }
+            if [ "$outcome" = "failure" ]; then
+              echo "One or more framework builds failed — see table above." >&2
+              exit 1
+            fi
           done
 
   # Runs even when the build job ends red (framework failure), as long as the

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -56,7 +56,9 @@ jobs:
       # Data comes from MotherDuck — no extract or dbt build needed.
 
       - name: Export Prefab dashboards
+        id: prefab
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
@@ -72,14 +74,18 @@ jobs:
           uv run prefab export dashboard/prefab/app_windows_2000.py -o preview/prefab/app_windows_2000.html
 
       - name: Build npm dashboard previews
+        id: npm
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           EVIDENCE_BASE_PATH: /evidence/build
         run: npm run build:npm-dashboards:preview
 
       - name: Build MDV dashboard
+        id: mdv
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           MDV_CACHE_DIR: ${{ runner.temp }}/fusion-mdv-cache/mdv-${{ env.MDV_SHA }}
@@ -89,7 +95,9 @@ jobs:
           cp dashboard/mdv/index.html preview/mdv/index.html
 
       - name: Build ggsql dashboard
+        id: ggsql
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           FUSION_DB: md:fusion_issues
@@ -99,7 +107,9 @@ jobs:
           cp dashboard/ggsql/index.html preview/ggsql/index.html
 
       - name: Export Marimo dashboard
+        id: marimo
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o preview/marimo.html
@@ -108,7 +118,9 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Render Quarto dashboard
+        id: quarto
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           QUARTO_PYTHON: ${{ github.workspace }}/.venv/bin/python3
@@ -120,7 +132,9 @@ jobs:
           cp -r index_files ../../preview/quarto/ 2>/dev/null || true
 
       - name: Build DAC dashboard
+        id: dac
         if: github.actor != 'dependabot[bot]'
+        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           DAC_ENVIRONMENT: prod
@@ -143,26 +157,27 @@ jobs:
         with:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const fmt = o => o === 'success' ? '✅' : o === 'failure' ? '❌' : o === 'skipped' ? '⏭️' : `⚠️ ${o}`;
             const body = [
               '## Dashboard Preview',
               '',
               `Download the preview artifact from [this workflow run](${runUrl}#artifacts) and open \`index.html\`.`,
               '',
-              '| Framework | File |',
-              '|-----------|------|',
-              '| Prefab | `prefab/app.html` |',
-              '| Prefab MySpace | `prefab/app_myspace.html` |',
-              '| Prefab Windows 2000 | `prefab/app_windows_2000.html` |',
-              '| ggsql + Vega-Lite | `ggsql/index.html` |',
-              '| mviz | `mviz/index.html` |',
-              '| MDV | `mdv/index.html` |',
-              '| Observable | `observable/index.html` |',
-              '| Evidence.dev | `evidence/index.html` |',
-              '| Marimo | `marimo.html` |',
-              '| Quarto | `quarto/index.html` |',
-              '| DAC | `dac/index.html` |',
-              '| Shaper | `shaper/index.html` |',
-              '| About | `about.html` |',
+              '| Framework | File | Status |',
+              '|-----------|------|--------|',
+              `| Prefab | \`prefab/app.html\` | ${fmt('${{ steps.prefab.outcome }}')} |`,
+              `| Prefab MySpace | \`prefab/app_myspace.html\` | ${fmt('${{ steps.prefab.outcome }}')} |`,
+              `| Prefab Windows 2000 | \`prefab/app_windows_2000.html\` | ${fmt('${{ steps.prefab.outcome }}')} |`,
+              `| ggsql + Vega-Lite | \`ggsql/index.html\` | ${fmt('${{ steps.ggsql.outcome }}')} |`,
+              `| mviz | \`mviz/index.html\` | ${fmt('${{ steps.npm.outcome }}')} |`,
+              `| MDV | \`mdv/index.html\` | ${fmt('${{ steps.mdv.outcome }}')} |`,
+              `| Observable | \`observable/index.html\` | ${fmt('${{ steps.npm.outcome }}')} |`,
+              `| Evidence.dev | \`evidence/index.html\` | ${fmt('${{ steps.npm.outcome }}')} |`,
+              `| Marimo | \`marimo.html\` | ${fmt('${{ steps.marimo.outcome }}')} |`,
+              `| Quarto | \`quarto/index.html\` | ${fmt('${{ steps.quarto.outcome }}')} |`,
+              `| DAC | \`dac/index.html\` | ${fmt('${{ steps.dac.outcome }}')} |`,
+              `| Shaper | \`shaper/index.html\` | ${fmt('${{ steps.prefab.outcome }}')} |`,
+              `| About | \`about.html\` | ${fmt('${{ steps.prefab.outcome }}')} |`,
               '',
               `_[Workflow run](${runUrl})_`,
             ].join('\n');
@@ -191,3 +206,31 @@ jobs:
                 body,
               });
             }
+
+      - name: Framework build summary
+        if: always() && github.actor != 'dependabot[bot]'
+        run: |
+          {
+            echo "## Framework build results"
+            echo ""
+            echo "| Framework | Result |"
+            echo "|-----------|--------|"
+            icon() { case $1 in success) echo "✅";; failure) echo "❌ **failed**";; *) echo "⚠️ $1";; esac; }
+            echo "| Prefab | $(icon '${{ steps.prefab.outcome }}') |"
+            echo "| npm (Observable + Evidence) | $(icon '${{ steps.npm.outcome }}') |"
+            echo "| MDV | $(icon '${{ steps.mdv.outcome }}') |"
+            echo "| ggsql | $(icon '${{ steps.ggsql.outcome }}') |"
+            echo "| Marimo | $(icon '${{ steps.marimo.outcome }}') |"
+            echo "| Quarto | $(icon '${{ steps.quarto.outcome }}') |"
+            echo "| DAC | $(icon '${{ steps.dac.outcome }}') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for outcome in \
+            '${{ steps.prefab.outcome }}' \
+            '${{ steps.npm.outcome }}' \
+            '${{ steps.mdv.outcome }}' \
+            '${{ steps.ggsql.outcome }}' \
+            '${{ steps.marimo.outcome }}' \
+            '${{ steps.quarto.outcome }}' \
+            '${{ steps.dac.outcome }}'; do
+            [ "$outcome" = "failure" ] && { echo "One or more framework builds failed — see table above." >&2; exit 1; }
+          done

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -232,5 +232,8 @@ jobs:
             '${{ steps.marimo.outcome }}' \
             '${{ steps.quarto.outcome }}' \
             '${{ steps.dac.outcome }}'; do
-            [ "$outcome" = "failure" ] && { echo "One or more framework builds failed — see table above." >&2; exit 1; }
+            if [ "$outcome" = "failure" ]; then
+              echo "One or more framework builds failed — see table above." >&2
+              exit 1
+            fi
           done

--- a/dashboard/dac/dashboards/fusion-issues.yml
+++ b/dashboard/dac/dashboards/fusion-issues.yml
@@ -125,7 +125,7 @@ rows:
   - widgets:
       - name: Slipped Through
         type: metric
-        col: 2
+        col: 3
         sql: |
           set file_search_path='transform';
           select slipped_through_count as value from issue_triage_health
@@ -133,7 +133,7 @@ rows:
         format: number
       - name: Triage Queue
         type: metric
-        col: 2
+        col: 3
         sql: |
           set file_search_path='transform';
           select triage_queue_count as value from issue_triage_health
@@ -141,7 +141,7 @@ rows:
         format: number
       - name: Hard Blockers
         type: metric
-        col: 2
+        col: 3
         sql: |
           set file_search_path='transform';
           select hard_blocker_count as value from issue_triage_health
@@ -149,15 +149,17 @@ rows:
         format: number
       - name: Needs Repro
         type: metric
-        col: 2
+        col: 3
         sql: |
           set file_search_path='transform';
           select needs_repro_count as value from issue_triage_health
         column: value
         format: number
+
+  - widgets:
       - name: Repro Verified
         type: metric
-        col: 2
+        col: 4
         sql: |
           set file_search_path='transform';
           select repro_verified_count as value from issue_triage_health
@@ -165,7 +167,7 @@ rows:
         format: number
       - name: Stale (90d+)
         type: metric
-        col: 2
+        col: 4
         sql: |
           set file_search_path='transform';
           select stale_count as value from issue_triage_health
@@ -173,7 +175,7 @@ rows:
         format: number
       - name: Total Open
         type: metric
-        col: 2
+        col: 4
         sql: |
           set file_search_path='transform';
           select total_open as value from issue_triage_health

--- a/dashboard/ggsql/queries/01_cumulative_flow.sql
+++ b/dashboard/ggsql/queries/01_cumulative_flow.sql
@@ -1,13 +1,13 @@
 -- title: Cumulative Issue Flow
 -- blurb: Running total of opened vs closed issues over time (excludes EPICs). Gap = issue debt.
 SELECT
-    week,
+    week::DATE AS week,
     'opened' AS series,
     cumulative_opened::DOUBLE AS issues
 FROM cumulative_flow
 UNION ALL
 SELECT
-    week,
+    week::DATE AS week,
     'closed' AS series,
     cumulative_closed::DOUBLE AS issues
 FROM cumulative_flow

--- a/dashboard/ggsql/queries/02_velocity.sql
+++ b/dashboard/ggsql/queries/02_velocity.sql
@@ -1,6 +1,6 @@
 -- title: Median Days to Close: Bugs vs Enhancements
 -- blurb: Weekly median close time by issue type. Tracks resolution velocity trends.
-SELECT week, issue_category, median_days
+SELECT week::DATE AS week, issue_category, median_days
 FROM velocity
 ORDER BY week
 VISUALISE week AS x, median_days AS y, issue_category AS color

--- a/dashboard/ggsql/queries/03_response_time.sql
+++ b/dashboard/ggsql/queries/03_response_time.sql
@@ -1,13 +1,13 @@
 -- title: Time to First Response (hours)
 -- blurb: Weekly p25/p50/p75 of hours from issue creation to first team response.
 SELECT week, 'p25' AS percentile, p25 AS hours
-FROM response_pctiles
+FROM (SELECT week::DATE AS week, p25, p50, p75 FROM response_pctiles) response_pctiles
 UNION ALL
 SELECT week, 'p50' AS percentile, p50 AS hours
-FROM response_pctiles
+FROM (SELECT week::DATE AS week, p25, p50, p75 FROM response_pctiles) response_pctiles
 UNION ALL
 SELECT week, 'p75' AS percentile, p75 AS hours
-FROM response_pctiles
+FROM (SELECT week::DATE AS week, p25, p50, p75 FROM response_pctiles) response_pctiles
 ORDER BY week
 VISUALISE week AS x, hours AS y, percentile AS color
 DRAW line

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -354,14 +354,3 @@ models:
       - name: age_days
         tests:
           - not_null
-
-  - name: oldest_untriaged
-    description: Top 25 oldest open non-EPIC issues with zero triage signal — the daily action queue
-    columns:
-      - name: issue_number
-        tests:
-          - not_null
-          - unique
-      - name: age_days
-        tests:
-          - not_null


### PR DESCRIPTION
## Summary

Fresh hotfix branch off `main` after #46 left two failures in CI/Deploy and one latent ggsql issue (introduced earlier by #58):

- **CI / Compile dbt models** — `transform/models/dashboard/_schema.yml` defined `oldest_untriaged` twice. dbt Fusion errors with `dbt1005: Found duplicate resource definitions`. Removed the duplicate block.
- **Deploy / Build DAC** — `dashboard/dac/dashboards/fusion-issues.yml` row 5 had 7 metric widgets at `col: 2`, summing to 14 (the grid is 12). Split into two rows: 4 metrics × `col: 3` and 3 metrics × `col: 4`.
- **Framework deploy isolation** — wrapped each framework export in `continue-on-error` with an `id`, added a "Framework build summary" step, set `if: always()` on `Upload Pages artifact`, and gated the `deploy` job on `needs.build.result != 'cancelled'`. One broken framework no longer takes the entire bakeoff offline. PR-preview comment now shows per-framework status icons.
- **ggsql `week::DATE` cast** — #58 changed the dashboard marts to emit `week` as `strftime`-formatted VARCHAR. Every other framework just renders it as a label, but ggsql's `SCALE x VIA date` requires a real DATE. Cast `week::DATE` in `01_cumulative_flow`, `02_velocity`, `03_response_time`. Models stay unchanged so other frameworks aren't disturbed.

#50 was closed because it shared history with the merged feature branch and CI wouldn't re-trigger for new pushes; this branch is fresh off `main`.

## Test plan

- [x] `dbtf compile --profiles-dir . --target prod` passes locally
- [x] All frameworks build green locally except DAC (installer is curl|bash, will rely on CI):
  - About, Shaper, Prefab (all 3 apps), npm (mviz/Observable/Evidence), MDV, ggsql, Marimo, Quarto
- [x] DAC YAML row math: every row sums to ≤12 by inspection
- [ ] CI green on this PR
- [ ] DAC step succeeds in CI
- [ ] PR preview comment renders per-framework status table

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)