### PR TITLE
Scope slipped_through_count to bugs only (#47)

### DIFF
--- a/dashboard/dac/dashboards/fusion-issues.yml
+++ b/dashboard/dac/dashboards/fusion-issues.yml
@@ -123,7 +123,7 @@ rows:
         y: [median_days_to_close]
 
   - widgets:
-      - name: Slipped Through
+      - name: Slipped through (bugs)
         type: metric
         col: 3
         sql: |

--- a/dashboard/evidence/pages/index.md
+++ b/dashboard/evidence/pages/index.md
@@ -18,7 +18,7 @@ select
 from issue_triage_health
 ```
 
-<BigValue data={operational_triage} value="slipped_through_count" title="Slipped Through"/>
+<BigValue data={operational_triage} value="slipped_through_count" title="Slipped through (bugs)"/>
 <BigValue data={operational_triage} value="triage_queue_count" title="In Triage Queue"/>
 <BigValue data={operational_triage} value="hard_blocker_count" title="Hard Blockers"/>
 <BigValue data={operational_triage} value="needs_repro_count" title="Needs Repro"/>

--- a/dashboard/marimo/app.py
+++ b/dashboard/marimo/app.py
@@ -59,7 +59,7 @@ def _(mo):
 def _(mo, query):
     ops = query("SELECT * FROM issue_triage_health").iloc[0]
     mo.hstack([
-        mo.stat(label="Slipped Through", value=str(int(ops['slipped_through_count'])), caption=f"{int(ops['slipped_through_bugs'])} bugs", bordered=True),
+        mo.stat(label="Slipped through (bugs)", value=str(int(ops['slipped_through_count'])), caption="zero triage signal", bordered=True),
         mo.stat(label="Triage Queue", value=str(int(ops['triage_queue_count'])), bordered=True),
         mo.stat(label="Hard Blockers", value=str(int(ops['hard_blocker_count'])), caption=f"{int(ops['hard_blocker_unreleased'])} unreleased", bordered=True),
         mo.stat(label="Needs Repro", value=str(int(ops['needs_repro_count'])), bordered=True),

--- a/dashboard/mdv/generate_data.py
+++ b/dashboard/mdv/generate_data.py
@@ -76,7 +76,7 @@ def write_csv(filename: str, rows: list[dict[str, Any]], fieldnames: list[str] |
 
 def build_triage_stats(triage: dict[str, Any]) -> list[dict[str, str]]:
     return [
-        {"label": "Slipped through (no signal)", "value": fmt_int(triage["slipped_through_count"]), "delta": ""},
+        {"label": "Slipped through (bugs)", "value": fmt_int(triage["slipped_through_count"]), "delta": ""},
         {"label": "In triage queue", "value": fmt_int(triage["triage_queue_count"]), "delta": ""},
         {"label": "Hard blockers", "value": fmt_int(triage["hard_blocker_count"]), "delta": ""},
         {"label": "Needs repro", "value": fmt_int(triage["needs_repro_count"]), "delta": ""},

--- a/dashboard/mviz/generate_data.py
+++ b/dashboard/mviz/generate_data.py
@@ -107,7 +107,7 @@ def main():
 
     # -- Operational triage (daily) --
     op_triage = query(con, "SELECT * FROM issue_triage_health")[0]
-    write_json("kpi_slipped_through.json", {"value": op_triage["slipped_through_count"], "label": "Slipped Through (no signal)"})
+    write_json("kpi_slipped_through.json", {"value": op_triage["slipped_through_count"], "label": "Slipped through (bugs)"})
     write_json("kpi_triage_queue.json", {"value": op_triage["triage_queue_count"], "label": "Triage Queue"})
     write_json("kpi_hard_blocker.json", {"value": op_triage["hard_blocker_count"], "label": "Hard Blockers"})
     write_json("kpi_op_stale.json", {"value": op_triage["stale_count"], "label": "Stale (90d+)"})

--- a/dashboard/observable/src/index.md
+++ b/dashboard/observable/src/index.md
@@ -26,7 +26,7 @@ const oldestUntriaged = await FileAttachment("data/oldest_untriaged.json").json(
 
 <div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">
   <div style="font-size:28px;font-weight:bold;color:#f38ba8">${triageHealth.slipped_through_count}</div>
-  <div style="color:#a6adc8;font-size:13px">Slipped through</div>
+  <div style="color:#a6adc8;font-size:13px">Slipped through (bugs)</div>
 </div>
 
 <div style="background:#1e1e2e;border:1px solid #313244;border-radius:8px;padding:16px;text-align:center">

--- a/dashboard/prefab/app.py
+++ b/dashboard/prefab/app.py
@@ -147,10 +147,10 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
     with Row(gap=3, css_class="mt-3"):
         with Card(css_class="flex-1"):
             with CardHeader():
-                CardTitle("Slipped through")
+                CardTitle("Slipped through (bugs)")
             with CardContent():
                 H3(str(triage_health["slipped_through_count"]))
-                Muted(f"{triage_health['slipped_through_bugs']} bugs · zero triage label")
+                Muted("Zero triage signal")
 
         with Card(css_class="flex-1"):
             with CardHeader():

--- a/dashboard/quarto/index.qmd
+++ b/dashboard/quarto/index.qmd
@@ -100,8 +100,8 @@ net = int(summary["closed_4w"]) - int(summary["opened_4w"])
 ## Operational Triage
 ```{python}
 #| content: valuebox
-#| title: "Slipped Through"
-dict(value=int(ops["slipped_through_count"]), caption=f"{int(ops['slipped_through_bugs'])} bugs", icon="exclamation-circle", color="danger")
+#| title: "Slipped through (bugs)"
+dict(value=int(ops["slipped_through_count"]), caption="zero triage signal", icon="exclamation-circle", color="danger")
 ```
 
 ```{python}

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -304,7 +304,7 @@ models:
           - not_null
 
   - name: issue_triage_health
-    description: Single-row counts of open non-EPIC issues across the triage taxonomy (slipped, queue, needs-repro, repro-verified, awaiting-release, hard-blocker, stale)
+    description: Single-row counts of open non-EPIC issues across the triage taxonomy (slipped-through bugs, queue, needs-repro, repro-verified, awaiting-release, hard-blocker, stale). `slipped_through_count` is scoped to `issue_category = 'bug'` since bugs are the only category that legitimately go through the triage queue.
     columns:
       - name: total_open
         tests:

--- a/transform/models/dashboard/issue_triage_health.sql
+++ b/transform/models/dashboard/issue_triage_health.sql
@@ -38,13 +38,12 @@ classified as (
 
 select
     count(*) as total_open,
-    count(case when triage_state = 'no_signal' then 1 end) as slipped_through_count,
+    count(case when triage_state = 'no_signal' and issue_category = 'bug' then 1 end) as slipped_through_count,
     count(case when triage_state = 'triage_queue' then 1 end) as triage_queue_count,
     count(case when triage_state = 'needs_repro' then 1 end) as needs_repro_count,
     count(case when triage_state = 'repro_verified' then 1 end) as repro_verified_count,
     count(case when triage_state = 'awaiting_release' then 1 end) as awaiting_release_count,
     count(case when has_hard_blocker = 1 then 1 end) as hard_blocker_count,
     count(case when is_stale = 1 then 1 end) as stale_count,
-    count(case when triage_state = 'no_signal' and issue_category = 'bug' then 1 end) as slipped_through_bugs,
     count(case when has_hard_blocker = 1 and has_awaiting_release = 0 then 1 end) as hard_blocker_unreleased
 from classified


### PR DESCRIPTION
## Summary

- Redefine `slipped_through_count` in `issue_triage_health` as bugs-only (`issue_category = 'bug'`) — the prior definition counted every open non-EPIC issue with no triage signal (~330), inflating it with enhancements and `other` that don't actually go through bug triage.
- Drop the now-redundant `slipped_through_bugs` column (it equals the new `slipped_through_count`).
- Update every dashboard consumer to a single "Slipped through (bugs)" card so the bugs-only scope is unambiguous.

Closes #47

## Test plan

- [x] `dbtf compile --profiles-dir . --target prod` (passes against MotherDuck)
- [x] Prefab export: `prefab export dashboard/prefab/app.py` — succeeds
- [x] mviz: `python dashboard/mviz/generate_data.py` — emits `kpi_slipped_through.json` with `value: 215, label: "Slipped through (bugs)"`
- [x] MDV: `python dashboard/mdv/generate_data.py` — succeeds
- [ ] DAC: skipped local smoke-test (`curl|bash` install denied locally); CI will validate the YAML
- [ ] Evidence / Observable / Quarto / ggsql / Marimo: not built locally, but each is a one-line edit (column rename consolidation + label change) and CI/preview will exercise them

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)