### PR TITLE
Fix Quarto Operational Triage layout collapsing value boxes

### DIFF
--- a/dashboard/quarto/index.qmd
+++ b/dashboard/quarto/index.qmd
@@ -97,7 +97,7 @@ priorities = query("SELECT * FROM community_priorities ORDER BY reactions_total_
 net = int(summary["closed_4w"]) - int(summary["opened_4w"])
 ```
 
-## Operational Triage
+## Operational Triage {height="160"}
 ```{python}
 #| content: valuebox
 #| title: "Slipped Through"
@@ -140,11 +140,9 @@ dict(value=int(ops["stale_count"]), icon="clock-history", color="secondary")
 dict(value=int(ops["total_open"]), icon="journal-text", color="primary")
 ```
 
-### Oldest Untriaged Issues
-Top 25 open non-EPIC issues with zero triage signal, ordered by age.
-
+## Oldest Untriaged Issues
 ```{python}
-#| title: "Oldest Untriaged"
+#| title: "Top 25 open non-EPIC issues with zero triage signal, ordered by age"
 untriaged
 ```
 


### PR DESCRIPTION
## Summary

PR #46 added an Operational Triage section to the Quarto dashboard that put 7 value boxes and the "Oldest Untriaged" table together inside a single `##` row (with the table under a `###` subheading). Quarto rendered that as an 8-column grid, and the table column — sized to fit ~25 rows — forced the entire row to stretch. The 7 value boxes inherited that height and collapsed to icon-only because their content only needs ~3em, while every section below got pushed off the viewport.

Fix:
- Promote `### Oldest Untriaged Issues` to its own `##` row so the table no longer cohabits with the value boxes.
- Pin the Operational Triage row to `height="160"` so a future neighbor cell can't restretch it.
- Move the descriptive blurb into the table's `title` so it doesn't render as a separate orphan card next to the table.

Verified by re-rendering `index.qmd`: outer grid is now `grid-template-rows: 160px minmax(3em, 1fr) ...`; value-box row is 7 columns each rendering an actual numeric value (215, 5, 5, 67, 36, 0, 324); Oldest Untriaged row is a single full-width column.

## Test plan

- [ ] CI builds the Quarto framework without errors
- [ ] PR preview deploys
- [ ] Visit the preview, click the Quarto tab, confirm:
  - Operational Triage row is one band of 7 value boxes (~160px tall) with visible numbers
  - "Oldest Untriaged" table sits directly below at full width
  - Key Metrics, charts, Triage Health, and Workload & Priorities sections are visible by scrolling

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)