### PR TITLE
Fix Prefab DataTable kwargs so rows actually render

### DIFF
--- a/dashboard/prefab/app.py
+++ b/dashboard/prefab/app.py
@@ -213,7 +213,7 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
             Muted(f"Top {len(oldest_untriaged)} open issues with zero triage signal — work this list")
         with CardContent():
             DataTable(
-                data=oldest_untriaged,
+                rows=oldest_untriaged,
                 columns=[
                     DataTableColumn(key="issue_number", header="#", sortable=True),
                     DataTableColumn(key="title", header="Title"),
@@ -225,7 +225,8 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
                     DataTableColumn(key="author_login", header="Author"),
                 ],
                 search=True,
-                pagination=15,
+                paginated=True,
+                page_size=15,
             )
 
     Separator(css_class="my-8")
@@ -491,7 +492,7 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
             Muted("Top 50 by age")
         with CardContent():
             DataTable(
-                data=open_issues_table,
+                rows=open_issues_table,
                 columns=[
                     DataTableColumn(key="#", header="#", sortable=True),
                     DataTableColumn(key="title", header="Title"),
@@ -502,7 +503,8 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
                     DataTableColumn(key="milestone", header="Milestone"),
                 ],
                 search=True,
-                pagination=15,
+                paginated=True,
+                page_size=15,
             )
 
     # ── Contributor Leaderboard ────────────────────────────────────


### PR DESCRIPTION
## Summary

The Prefab dashboard's two DataTable instances ("Oldest untriaged issues" and "Oldest Open Issues") have been baking in **empty rows** since the prefab_ui API used `rows=`/`paginated=`/`page_size=` — but the callsites still pass `data=` and `pagination=15`. Pydantic silently drops unknown kwargs, so `rows` defaults to empty and the static export contains `"rows": []`.

The static HTML at https://dashboard-bakeoff.anders.omg.lol/prefab/app.html shows `"rows": []` for both DataTables, even when the underlying `oldest_untriaged` mart has 25 rows. Renders as "No results" in the UI.

## Fix

Switch to the documented kwarg names:
- `data=` → `rows=`
- `pagination=15` → `paginated=True, page_size=15`

Two callsites in `dashboard/prefab/app.py` (lines ~215 and ~494). The other `data=` references in the file are for chart components, which legitimately take `data=`.

## Test plan

- [x] `uv run prefab export dashboard/prefab/app.py -o /tmp/x.html`
- [x] Local export now bakes in 25 rows for Oldest Untriaged and 50 for Oldest Open Issues
- [x] HTML size grows 154KB → 184KB (matches the inlined data)
- [ ] CI green
- [ ] Live dashboard renders both tables after deploy

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)