### PR TITLE
Scope oldest_untriaged to bugs only (#47 follow-on)

### DIFF
--- a/dashboard/dac/dashboards/fusion-issues.yml
+++ b/dashboard/dac/dashboards/fusion-issues.yml
@@ -183,7 +183,7 @@ rows:
         format: number
 
   - widgets:
-      - name: Oldest Untriaged Issues
+      - name: Oldest Untriaged Bugs
         type: table
         col: 12
         sql: |

--- a/dashboard/evidence/pages/index.md
+++ b/dashboard/evidence/pages/index.md
@@ -35,7 +35,7 @@ from oldest_untriaged
 order by age_days desc
 ```
 
-<DataTable data={oldest_untriaged} rows=25 title="Oldest Untriaged Issues">
+<DataTable data={oldest_untriaged} rows=25 title="Oldest Untriaged Bugs">
   <Column id="issue_number" title="#"/>
   <Column id="title" title="Title"/>
   <Column id="age_days" title="Age (days)"/>

--- a/dashboard/marimo/app.py
+++ b/dashboard/marimo/app.py
@@ -73,8 +73,8 @@ def _(mo, query):
 @app.cell
 def _(mo):
     mo.md("""
-    ### Oldest Untriaged Issues
-    Top 25 open non-EPIC issues with zero triage signal, ordered by age.
+    ### Oldest Untriaged Bugs
+    Top 25 open bugs with zero triage signal, ordered by age.
     """)
     return
 

--- a/dashboard/observable/src/index.md
+++ b/dashboard/observable/src/index.md
@@ -56,7 +56,7 @@ const oldestUntriaged = await FileAttachment("data/oldest_untriaged.json").json(
 
 </div>
 
-### Oldest untriaged issues
+### Oldest untriaged bugs
 
 <table style="width:100%;border-collapse:collapse;margin:12px 0">
   <thead>

--- a/dashboard/prefab/app.py
+++ b/dashboard/prefab/app.py
@@ -209,8 +209,8 @@ with PrefabApp(css_class="max-w-7xl mx-auto p-6") as app:
     # ── Oldest untriaged action queue ──────────────────────────────
     with Card(css_class="mt-6"):
         with CardHeader():
-            CardTitle("Oldest untriaged issues")
-            Muted(f"Top {len(oldest_untriaged)} open issues with zero triage signal — work this list")
+            CardTitle("Oldest untriaged bugs")
+            Muted(f"Top {len(oldest_untriaged)} open bugs with zero triage signal — work this list")
         with CardContent():
             DataTable(
                 rows=oldest_untriaged,

--- a/dashboard/quarto/index.qmd
+++ b/dashboard/quarto/index.qmd
@@ -140,9 +140,9 @@ dict(value=int(ops["stale_count"]), icon="clock-history", color="secondary")
 dict(value=int(ops["total_open"]), icon="journal-text", color="primary")
 ```
 
-## Oldest Untriaged Issues
+## Oldest Untriaged Bugs
 ```{python}
-#| title: "Top 25 open non-EPIC issues with zero triage signal, ordered by age"
+#| title: "Top 25 open bugs with zero triage signal, ordered by age"
 untriaged
 ```
 

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -345,7 +345,7 @@ models:
           - not_null
 
   - name: oldest_untriaged
-    description: Top 25 oldest open non-EPIC issues with zero triage signal — the daily action queue
+    description: Top 25 oldest open bugs with zero triage signal — the daily action queue
     columns:
       - name: issue_number
         tests:

--- a/transform/models/dashboard/oldest_untriaged.sql
+++ b/transform/models/dashboard/oldest_untriaged.sql
@@ -1,4 +1,5 @@
-{# Oldest open non-EPIC issues with zero triage signal — the daily action queue. #}
+{# Oldest open bugs with zero triage signal — the daily action queue.
+   Mirrors the bugs-only scope of `slipped_through_count` (issue #47). #}
 
 with issue_labels_agg as (
     select
@@ -24,7 +25,7 @@ select
 from {{ ref('fct_issues') }} i
 left join issue_labels_agg l using (issue_dlt_id)
 where i.state = 'OPEN'
-  and i.issue_category != 'epic'
+  and i.issue_category = 'bug'
   and coalesce(l.has_triage_signal, 0) = 0
 order by i.created_at asc
 limit 25


### PR DESCRIPTION
## Summary

The Oldest Untriaged action queue is showing enhancements and \`other\`-categorized issues alongside bugs. It should only show bugs, mirroring the bugs-only scoping applied to \`slipped_through_count\` in #52.

This filter goes in at the mart (\`transform/models/dashboard/oldest_untriaged.sql\`) so all 9 dashboard consumers inherit it. Surface labels updated everywhere from "Oldest Untriaged Issues" to "Oldest Untriaged Bugs".

## Known limitation (follow-up needed)

\`issue_category\` is currently derived from **labels only** (\`bug\` / \`enhancement\` / \`EPIC\`). The extract pipeline doesn't pull GitHub's native **Issue Type** field — so issues like #8 (Type: Feature, no \`enhancement\` label) and #10 (Type: Task) are categorized as \`'other'\` and won't appear in any category-filtered view.

Plan: add \`issueType { name }\` to the GraphQL \`ISSUES_QUERY\`, expose it in \`stg_issues\`, and add it to the \`fct_issues.issue_category\` CASE. Tracking as a follow-up.

## Test plan

- [x] \`dbtf build --select oldest_untriaged --target prod\` passes (4/4 success)
- [x] Re-queried mart locally — all 25 rows now have \`issue_category = 'bug'\`
- [ ] CI green
- [ ] Live dashboard renders bugs only after deploy

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)