### PR TITLE
Use GitHub Issue Type in issue_category

### DIFF
--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -85,8 +85,14 @@ def get_reactions_data(
         "first_timeline_items": 50,
         "node_type": node_type,
     }
+    issue_type_fragment = (
+        "issueType { name }" if node_type == "issues" else ""
+    )
+    query = (ISSUES_QUERY % node_type).replace(
+        "__ISSUE_TYPE_FRAGMENT__", issue_type_fragment
+    )
     for page_items in _get_graphql_pages(
-        access_token, ISSUES_QUERY % node_type, variables, node_type, max_items
+        access_token, query, variables, node_type, max_items
     ):
         # use reactionGroups to query for reactions to comments that have any reactions. reduces cost by 10-50x
         reacted_comment_ids = {}

--- a/extract/github/queries.py
+++ b/extract/github/queries.py
@@ -29,6 +29,7 @@ query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions:
         createdAt
         state
         updatedAt
+        __ISSUE_TYPE_FRAGMENT__
         labels(first: 25) {
           nodes {
             name

--- a/transform/models/dashboard/issues.sql
+++ b/transform/models/dashboard/issues.sql
@@ -3,6 +3,7 @@ select
     title,
     state,
     issue_category,
+    issue_type,
     created_at,
     closed_at,
     hours_to_close,

--- a/transform/models/marts/_schema.yml
+++ b/transform/models/marts/_schema.yml
@@ -1,0 +1,40 @@
+version: 2
+
+models:
+  - name: fct_issues
+    description: >
+      One row per GitHub issue with derived metrics (time-to-close, time-to-first-response),
+      label-derived flags, and a coarse `issue_category` classification.
+    columns:
+      - name: issue_dlt_id
+        tests:
+          - not_null
+          - unique
+      - name: issue_number
+        tests:
+          - not_null
+          - unique
+      - name: state
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['OPEN', 'CLOSED']
+      - name: issue_type
+        description: >
+          Raw value of GitHub's native Issue Type field. Common values:
+          'Bug', 'Feature', 'Task', 'Epic'. NULL when the issue has no type set,
+          or for repos that don't use Issue Types.
+      - name: issue_category
+        description: >
+          Coarse bucket — 'bug', 'enhancement', 'epic', or 'other'.
+          Resolved by combining label-derived flags (`bug` / `enhancement` / `EPIC`)
+          with GitHub's native Issue Type ('Bug' / 'Feature' / 'Epic').
+          'Feature' and 'Enhancement' Issue Types both map to 'enhancement'.
+          Issues with Issue Type 'Task' (or any unrecognized type) without a
+          matching label fall into 'other'.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['bug', 'enhancement', 'epic', 'other']

--- a/transform/models/marts/fct_issues.sql
+++ b/transform/models/marts/fct_issues.sql
@@ -50,6 +50,7 @@ select
     i.closed,
     i.author_login,
     i.author_association,
+    i.issue_type,
     i.milestone_number,
     i.milestone_title,
     i.reactions_total_count,
@@ -79,9 +80,9 @@ select
 
     -- classification
     case
-        when il.has_epic = 1 then 'epic'
-        when il.has_bug = 1 then 'bug'
-        when il.has_enhancement = 1 then 'enhancement'
+        when il.has_epic = 1 or i.issue_type = 'Epic' then 'epic'
+        when il.has_bug = 1 or i.issue_type = 'Bug' then 'bug'
+        when il.has_enhancement = 1 or i.issue_type in ('Feature', 'Enhancement') then 'enhancement'
         else 'other'
     end as issue_category,
 

--- a/transform/models/staging/_sources.yml
+++ b/transform/models/staging/_sources.yml
@@ -26,6 +26,10 @@ models:
           - accepted_values:
               arguments:
                 values: ['OPEN', 'CLOSED']
+      - name: issue_type
+        description: >
+          Native GitHub Issue Type name (e.g., 'Bug', 'Feature', 'Task', 'Epic').
+          NULL when no Issue Type is set on the issue.
       - name: created_at
         tests:
           - not_null

--- a/transform/models/staging/stg_issues.sql
+++ b/transform/models/staging/stg_issues.sql
@@ -14,6 +14,7 @@ renamed as (
         author__login as author_login,
         author__avatar_url as author_avatar_url,
         author_association,
+        issue_type__name as issue_type,
         milestone__number as milestone_number,
         milestone__title as milestone_title,
         milestone__description as milestone_description,


### PR DESCRIPTION
## Summary

- `fct_issues.issue_category` now considers GitHub's native Issue Type (Bug/Feature/Epic) alongside the existing `bug`/`enhancement`/`EPIC` labels
- Adds `issue_type` as a raw passthrough column on `fct_issues` (and on the dashboard `issues` model)
- Documents `fct_issues` in a new `models/marts/_schema.yml`

## Why

The dbt-fusion repo categorizes most issues via GitHub's native Issue Type field rather than labels. Our pipeline only looked at labels, so issues like #8 (Type: Feature, no `enhancement` label) were silently bucketed as `'other'`. This understated bug/feature counts and inflated `'other'`.

## Mapping

| Issue Type | issue_category |
|---|---|
| `Epic` | `epic` |
| `Bug` | `bug` |
| `Feature`, `Enhancement` | `enhancement` |
| `Task` (and any unrecognized type) | falls through — labels still considered, otherwise `'other'` |
| `NULL` | label-only logic (unchanged) |

`Task` deliberately lands in `'other'` unless there's a matching label — Tasks are typically internal/maintenance work, not bug or feature delivery, so grouping them with `enhancement` would distort velocity metrics.

In the actual data only `Bug` (887) / `Feature` (241) / `Task` (79) / `NULL` (295) appear — `Epic` and `Enhancement` are accepted-but-unused for forward compatibility.

## Dependencies

Branch is rebased on top of #57 (extract layer). Merge #57 first, then this.

## Validation against prod (md:fusion_issues)

After full `dbt build --target prod --static-analysis strict` (178/178 success, 0 errors):

```
issue_category distribution:
  bug          1055
  enhancement   277
  other         127
  epic           43
```

Canary issues:

| # | issue_type | issue_category |
|---|---|---|
| 8 | Feature | enhancement ✅ |
| 9 | Feature | enhancement ✅ |
| 10 | Task | other ✅ |
| 11 | Feature | enhancement ✅ |

## Test plan

- [x] `dbt build --target prod --static-analysis strict` passes (178/178)
- [x] Canary issues #8/#9/#11 → `enhancement`, #10 → `other`
- [x] New `accepted_values` test on `issue_category` passes

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)