### PR TITLE
Pull GitHub Issue Type into stg_issues

### DIFF
--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -85,8 +85,14 @@ def get_reactions_data(
         "first_timeline_items": 50,
         "node_type": node_type,
     }
+    issue_type_fragment = (
+        "issueType { name }" if node_type == "issues" else ""
+    )
+    query = (ISSUES_QUERY % node_type).replace(
+        "__ISSUE_TYPE_FRAGMENT__", issue_type_fragment
+    )
     for page_items in _get_graphql_pages(
-        access_token, ISSUES_QUERY % node_type, variables, node_type, max_items
+        access_token, query, variables, node_type, max_items
     ):
         # use reactionGroups to query for reactions to comments that have any reactions. reduces cost by 10-50x
         reacted_comment_ids = {}

--- a/extract/github/queries.py
+++ b/extract/github/queries.py
@@ -29,6 +29,7 @@ query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions:
         createdAt
         state
         updatedAt
+        __ISSUE_TYPE_FRAGMENT__
         labels(first: 25) {
           nodes {
             name

--- a/transform/models/staging/_sources.yml
+++ b/transform/models/staging/_sources.yml
@@ -26,6 +26,10 @@ models:
           - accepted_values:
               arguments:
                 values: ['OPEN', 'CLOSED']
+      - name: issue_type
+        description: >
+          Native GitHub Issue Type name (e.g., 'Bug', 'Feature', 'Task', 'Epic').
+          NULL when no Issue Type is set on the issue.
       - name: created_at
         tests:
           - not_null

--- a/transform/models/staging/stg_issues.sql
+++ b/transform/models/staging/stg_issues.sql
@@ -14,6 +14,7 @@ renamed as (
         author__login as author_login,
         author__avatar_url as author_avatar_url,
         author_association,
+        issue_type__name as issue_type,
         milestone__number as milestone_number,
         milestone__title as milestone_title,
         milestone__description as milestone_description,


### PR DESCRIPTION
## Summary
- Add `issueType { name }` to the issues GraphQL query so we capture GitHub's native Issue Type (Bug / Feature / Task / Epic).
- Expose it as `stg_issues.issue_type` (VARCHAR, nullable). Modeling layer (separate PR) consumes this to fix `fct_issues.issue_category`.
- Guards the new field with a template substitution because the same query body is reused for `pullRequests`, which has no `issueType` field.

**Why:** Issues like #8 (Type: Feature, no `enhancement` label) and #10 (Type: Task) were falling through to `'other'` in the dashboard category logic, masking real feature-request and task volume.

## Test plan
- [x] Extract ran end-to-end against MotherDuck (`uv run python run.py --motherduck`) — pipeline LOADED, no failed jobs.
- [x] Raw column lands as `raw_github.issues.issue_type__name`.
- [x] `dbt build --target prod --select stg_issues` succeeds; all 11 tests pass.
- [x] `stg_issues.issue_type` distribution: Bug=887, NULL=295, Feature=241, Task=79.
- [x] Spot-check matches GitHub UI: #8=Feature, #9=Feature, #10=Task, #11=Feature.
- [x] PullRequest extraction unaffected — `issueType` fragment is omitted for the `pullRequests` query.

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)