### PR TITLE
Install official DuckDB ADBC driver in CI to dodge dbt-fusion#1574

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,15 @@ jobs:
           curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      # Workaround for dbt-labs/dbt-fusion#1574 — see extract.yml for context.
+      - name: Install DuckDB ADBC driver (dbt-fusion#1574 workaround)
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          curl -LsSf https://dbc.columnar.tech/install.sh | sh
+          dbc install duckdb
+
       - name: Compile dbt models
         if: github.actor != 'dependabot[bot]'
-        timeout-minutes: 5
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -35,10 +35,19 @@ jobs:
           curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      # Workaround for dbt-labs/dbt-fusion#1574 — Fusion's bespoke DuckDB ADBC
+      # driver SIGFPEs against MotherDuck on Linux x86_64. Installing the
+      # official DuckDB ADBC driver via `dbc` (from columnar.tech) puts it on
+      # the system path; Fusion's existing LoadStrategy::SystemThenCdnCache
+      # finds the system driver first and avoids the broken bespoke one.
+      # Track dbt-labs/fs#9958 + dbt-labs/fs#10002 — once those merge, this
+      # step becomes unnecessary.
+      - name: Install DuckDB ADBC driver (dbt-fusion#1574 workaround)
+        run: |
+          curl -LsSf https://dbc.columnar.tech/install.sh | sh
+          dbc install duckdb
+
       - name: Refresh dbt models in MotherDuck
-        # TODO: Remove timeout + continue-on-error once dbt-labs/dbt-fusion#1574 is fixed
-        timeout-minutes: 5
-        continue-on-error: true
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Fusion's bespoke DuckDB ADBC driver SIGFPEs against MotherDuck on Linux x86_64 — see [dbt-labs/dbt-core#14492](https://github.com/dbt-labs/dbt-core/issues/14492). Our `Refresh dbt models in MotherDuck` step has been masking the crash with `timeout-minutes: 5` + `continue-on-error: true`, which means the prod MotherDuck mart only refreshes when someone manually runs `dbt build` from a Mac. That's how we ended up shipping a stale `slipped_through_count` and an empty Untriaged table earlier today (#52, dbt-labs/dbt-fusion#54, dbt-labs/dbt-core#13145, dbt-labs/dbt-fusion#56, dbt-labs/dbt-fusion#57).

## Workaround

[dbt-labs/fs#10002](https://github.com/dbt-labs/fs/pull/10002) explains the root cause: ABI mismatch between the bespoke driver and the published `motherduck.duckdb_extension`. Per that PR, Fusion already has `LoadStrategy::SystemThenCdnCache` — it tries a system-installed DuckDB ADBC driver first, then falls back to the broken bespoke one. So if we install the official driver on the runner before `dbt build`, Fusion picks it up and skips the crash.

[dbc](https://columnar.tech/dbc) (Columnar.tech's ADBC driver manager) has a one-line install that does exactly that:

```yaml
- name: Install DuckDB ADBC driver (dbt-fusion#1574 workaround)
  run: |
    curl -LsSf https://dbc.columnar.tech/install.sh | sh
    dbc install duckdb
```

Added that step to:
- `.github/workflows/extract.yml` before "Refresh dbt models in MotherDuck"
- `.github/workflows/ci.yml` before "Compile dbt models"

Also dropped the now-unnecessary `timeout-minutes: 5` and `continue-on-error: true` from the extract step so failures surface instead of getting swallowed.

## When to remove this step

Once [dbt-labs/fs#9958](https://github.com/dbt-labs/fs/pull/9958) (`wire DuckDB adapter to official libduckdb CDN driver`) ships in a Fusion release, the bespoke driver is gone and this step becomes unnecessary.

## Test plan

- [ ] CI run on this PR confirms `Compile dbt models` finishes in seconds (vs hanging 5 min and getting killed)
- [ ] After merge, watch the next scheduled extract.yml — the dbt build should actually complete and refresh the mart, instead of timing out

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)