### PR TITLE
Add epic/task hierarchy modeling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,6 @@ uv run prefab export dashboard/app_myspace.py -o dashboard/app_myspace.html
 
 ## PR Guidelines
 
-- **Always include a dashboard preview link in the PR body.** The PR preview workflow deploys a preview to GitHub Pages on every PR. After the workflow runs, a bot comment will appear with the preview URL. Include this in the PR description:
-  ```
-  ## Dashboard Preview
-  🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)
-  ```
 - Use feature branches, never push directly to main.
 - Commit messages should explain "why" not "what".
 - PRs that change a Prefab dashboard should verify the export works: `uv run prefab export dashboard/app.py -o /tmp/test.html`

--- a/docs/superpowers/plans/2026-05-08-epic-task-hierarchy.md
+++ b/docs/superpowers/plans/2026-05-08-epic-task-hierarchy.md
@@ -406,6 +406,7 @@ models:
                 field: issue_number
               config:
                 where: "parent_number is not null"
+                severity: warn  # parent may be cross-repo or pre-extract; warn rather than block
 ```
 
 - [ ] **Step 2: Run tests**
@@ -967,7 +968,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 2: Confirm with user**
+- [ ] **Step 3: Confirm with user**
 
 Surface the PR URL and stop. Do not merge — leave that to the user.
 

--- a/docs/superpowers/plans/2026-05-08-epic-task-hierarchy.md
+++ b/docs/superpowers/plans/2026-05-08-epic-task-hierarchy.md
@@ -1,0 +1,981 @@
+# Epic / Task hierarchy modeling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `is_epic`, `has_epic_parent`, `is_orphan` columns to `fct_issues`; create `fct_epics` and `fct_milestones` marts; add three audit views and an `epic_burndown` model — so the warehouse can answer "is every issue attributed to an epic, and is every epic attributed to a milestone?"
+
+**Architecture:**
+- Pull `issueType { name }` and `parent { number, title, issueType { name } }` from GitHub GraphQL.
+- Plumb both through `stg_issues` → `fct_issues`.
+- Build `fct_epics` (one row per Epic, with child rollups) and `fct_milestones` (one row per milestone, with epic/task counts) on top.
+- Layer audit views and per-epic burndown on top of those marts using the same date-spine reconstruction technique already used by `metrics/milestone_burndown.sql`.
+
+**Tech Stack:**
+- Python `uv` for the extract (`extract/run.py`)
+- dlt for GraphQL→parquet/MotherDuck loading
+- dbt Fusion (`dbtf`) over DuckDB / MotherDuck
+- `--static-analysis strict` is enforced
+
+**Spec:** `docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md`
+
+---
+
+## File map
+
+**Extract:**
+- Modify: `extract/github/queries.py` — add `issueType` and `parent` to `ISSUES_QUERY`.
+
+**Staging:**
+- Modify: `transform/models/staging/_sources.yml` — declare 4 new raw columns.
+- Modify: `transform/models/staging/stg_issues.sql` — passthrough `issue_type`, `parent_number`, `parent_title`, `parent_issue_type`.
+
+**Marts:**
+- Modify: `transform/models/marts/fct_issues.sql` — passthrough `issue_type` + 4 milestone fields + 3 parent fields; add `is_epic`, `has_epic_parent`, `is_orphan`; broaden `issue_category`.
+- Create: `transform/models/marts/_schema.yml` — declare new columns and tests for `fct_issues`, `fct_epics`, `fct_milestones`.
+- Create: `transform/models/marts/fct_epics.sql` — one row per Epic.
+- Create: `transform/models/marts/fct_milestones.sql` — one row per milestone with rollups.
+
+**Metrics & audits:**
+- Create: `transform/models/metrics/audit_orphan_issues.sql`
+- Create: `transform/models/metrics/audit_epics_without_milestone.sql`
+- Create: `transform/models/metrics/audit_tasks_without_milestone.sql`
+- Create: `transform/models/metrics/epic_burndown.sql`
+- Modify: `transform/models/metrics/milestone_burndown.sql` — join `fct_milestones` for `milestone_state`, `is_overdue`, `total_issues`.
+
+**Cross-model integrity:**
+- Create: `transform/tests/audit_epics_orphan_count_matches.sql` — singular test that `audit_epics_without_milestone` rowcount equals `count(*) filter (is_orphan_epic)` on `fct_epics`.
+
+**Verification commands** (used throughout):
+- Local dev build: `cd transform && dbtf build --profiles-dir . --target dev`
+- Prod static-analysis build: `cd transform && dbtf build --profiles-dir . --target prod --static-analysis strict`
+- Tests only: `cd transform && dbtf test --profiles-dir . --target dev`
+- Single model: `cd transform && dbtf build --profiles-dir . --target dev --select <model_name>`
+
+---
+
+## Task 0: Create feature branch
+
+Per `CLAUDE.md`, never push directly to `main`. Branch first.
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout -b feat/epic-task-hierarchy
+```
+
+- [ ] **Step 2: Verify clean state**
+
+```bash
+git status
+```
+
+Expected: `On branch feat/epic-task-hierarchy. nothing to commit, working tree clean.`
+
+---
+
+## Task 1: Pull `issueType` and `parent` from GitHub GraphQL
+
+Both extract changes ship together because they require one extract re-run. The query body is reused for `pullRequests` (via the `%s` template substitution at line 13), where `issueType` and `parent` are not valid fields. Existing convention uses simple inline guarding — verify the same approach works.
+
+**Files:**
+- Modify: `extract/github/queries.py:10-95`
+
+- [ ] **Step 1: Inspect existing query reuse pattern**
+
+Read `extract/github/queries.py:10-95` and `extract/github/helpers.py` lines that use `ISSUES_QUERY % node_type` (around `helpers.py:88`). Confirm `node_type` is one of `"issues"` or `"pullRequests"`.
+
+- [ ] **Step 2: Check whether a previous attempt already added `issueType`**
+
+```bash
+grep -n -i "issuetype\|parent" extract/github/queries.py
+```
+
+If the file already has `issueType { name }` *and* a `parent { ... }` block, skip to Task 2. Otherwise, continue.
+
+- [ ] **Step 3: Add `issueType` and `parent` to the issue node**
+
+In `extract/github/queries.py:ISSUES_QUERY`, add inside the issue node selection (alongside `state`, `closed`, etc., before the `labels` block at line 32):
+
+```graphql
+        issueType { name }
+        parent {
+          number
+          title
+          issueType { name }
+        }
+```
+
+`issueType` and `parent` are only valid on `Issue`, not `PullRequest`. The existing `%s` substitution swaps `issues` for `pullRequests` at the connection level, so the inner fields apply to both. To prevent GraphQL errors when the same body runs against `pullRequests`, wrap both fields in an inline fragment:
+
+```graphql
+        ... on Issue {
+          issueType { name }
+          parent {
+            number
+            title
+            issueType { name }
+          }
+        }
+```
+
+This is the cleanest way to scope issue-only fields in a body shared with `pullRequests`. (Inline fragments on the same type are a no-op syntactically but resolve the field-validity issue.)
+
+- [ ] **Step 4: Manual smoke check of the query**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "from extract.github.queries import ISSUES_QUERY; print(ISSUES_QUERY % 'issues')" | head -40
+```
+
+Expected: see `... on Issue { issueType { name } parent { ... } }` block in the output. No syntax errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extract/github/queries.py
+git commit -m "Pull issueType and parent from GitHub GraphQL
+
+Adds issueType { name } and parent { number, title, issueType { name } }
+to ISSUES_QUERY, scoped via inline fragment on Issue so the same query
+body still works for pullRequests."
+```
+
+---
+
+## Task 2: Declare new raw columns in `_sources.yml`
+
+dlt's GraphQL flattening produces `issue_type__name`, `parent__number`, `parent__title`, `parent__issue_type__name`. Static analysis needs them declared.
+
+**Files:**
+- Modify: `transform/models/staging/_sources.yml`
+
+- [ ] **Step 1: Read current `_sources.yml`**
+
+Read `transform/models/staging/_sources.yml` to find the `issues` table block under `raw_github`.
+
+- [ ] **Step 2: Add column declarations**
+
+Under the `issues` table's `columns:` list, add (preserving existing entries):
+
+```yaml
+      - name: issue_type__name
+        description: GitHub native Issue Type (Bug | Feature | Task | Epic | null)
+      - name: parent__number
+        description: Parent issue number via GitHub sub-issues
+      - name: parent__title
+        description: Parent issue title
+      - name: parent__issue_type__name
+        description: Parent issue's native Issue Type
+```
+
+If the `issues` table block does not yet have a `columns:` list, add one. If unsure of the exact YAML shape, model after the `stg_issues` model entry already in this file (which uses `columns:` lists with `name`/`description`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add transform/models/staging/_sources.yml
+git commit -m "Declare issue_type and parent columns on raw_github.issues source"
+```
+
+---
+
+## Task 3: Re-run extract to populate the new columns
+
+dlt only writes columns it sees data for. The new columns won't exist until the extract runs once.
+
+**Files:** none changed; this is a data-loading step.
+
+- [ ] **Step 1: Run the extract**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis/extract
+uv run python run.py
+```
+
+Expected: extract completes without errors. Either a `data/raw/fusion_issues/issues/*.parquet` file is updated, or MotherDuck's `raw_github.issues` is replaced — depending on local config.
+
+- [ ] **Step 2: Verify new columns landed**
+
+For dev (parquet):
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "import duckdb; con = duckdb.connect(); con.execute(\"select count(*) c, count(issue_type__name) c_type, count(parent__number) c_parent from read_parquet('data/raw/fusion_issues/issues/*.parquet')\"); print(con.fetchall())"
+```
+
+Expected: `c` > 0, `c_type` > 0 (most issues have a type now), `c_parent` ≥ 0 (at least some sub-issues exist in dbt-fusion).
+
+If `c_type` = 0 or `c_parent` is suspiciously low, the GraphQL change in Task 1 is wrong — back to that task.
+
+- [ ] **Step 3: No commit (data files are gitignored)**
+
+---
+
+## Task 4: Passthrough new columns in `stg_issues`
+
+**Files:**
+- Modify: `transform/models/staging/stg_issues.sql`
+
+- [ ] **Step 1: Read current `stg_issues.sql`**
+
+Read `transform/models/staging/stg_issues.sql` lines 1-33. Confirm the `renamed` CTE structure.
+
+- [ ] **Step 2: Add passthroughs**
+
+Inside the `renamed` CTE's select, after the existing `closed_at` column (line 28), add:
+
+```sql
+        issue_type__name as issue_type,
+        parent__number as parent_number,
+        parent__title as parent_title,
+        parent__issue_type__name as parent_issue_type
+```
+
+- [ ] **Step 3: Build stg_issues alone**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select stg_issues
+```
+
+Expected: builds clean. If a column-not-found error fires, the extract didn't actually emit that column — re-check Task 3 step 2 column names exactly (note the double underscores from dlt flattening).
+
+- [ ] **Step 4: Spot-check the data**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "import duckdb; con = duckdb.connect('data/fusion_issues.duckdb'); print(con.execute('select issue_type, count(*) from main_staging.stg_issues group by 1 order by 2 desc').fetchall())"
+```
+
+(If the schema name differs, adjust — e.g., `dbt_dev.stg_issues`. Run `con.execute(\"show tables\").fetchall()` to find it.)
+
+Expected: a small set of issue_type values like `('Task', N)`, `('Bug', N)`, `('Feature', N)`, `(None, N)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transform/models/staging/stg_issues.sql
+git commit -m "Passthrough issue_type and parent fields in stg_issues"
+```
+
+---
+
+## Task 5: Add new columns to `fct_issues`
+
+This is the biggest single-file change. Bundles three logically-related additions: `issue_type` + milestone passthroughs (Phase 0), parent passthroughs + `has_epic_parent` (Phase 1), `is_epic` + `is_orphan` (Phase 2).
+
+**Files:**
+- Modify: `transform/models/marts/fct_issues.sql`
+
+- [ ] **Step 1: Read current `fct_issues.sql`**
+
+Re-read the file end-to-end. Note the existing structure: `issues` CTE, `first_comments`, `first_non_author_comments`, `issue_labels`, `triage_info`, then the final `select` joining them.
+
+- [ ] **Step 2: Update the final select**
+
+Make these edits to the final `select` (around line 43 onward):
+
+(a) Right before `i.reactions_total_count` (~line 55), add:
+
+```sql
+    i.issue_type,
+    i.milestone_state,
+    i.milestone_due_on,
+    i.milestone_created_at,
+    i.milestone_closed_at,
+    i.parent_number,
+    i.parent_title,
+    i.parent_issue_type,
+```
+
+(b) Replace the `-- classification` block (currently lines 81-86) with the broadened version that considers `issue_type` alongside labels:
+
+```sql
+    -- classification
+    case
+        when il.has_epic = 1 then 'epic'
+        when i.issue_type = 'Bug' or il.has_bug = 1 then 'bug'
+        when i.issue_type in ('Feature', 'Enhancement') or il.has_enhancement = 1 then 'enhancement'
+        when i.issue_type = 'Task' then 'task'
+        else 'other'
+    end as issue_category,
+```
+
+(c) After the existing `has_milestone` line (~line 96, the last column before the `from`), add:
+
+```sql
+    ,case
+        when i.issue_type = 'Task' and lower(i.title) like '%epic%'
+        then true else false
+    end as is_epic
+    ,case
+        when i.parent_issue_type = 'Task' and lower(i.parent_title) like '%epic%'
+        then true else false
+    end as has_epic_parent
+    ,case
+        when i.state = 'OPEN'
+            and not (i.issue_type = 'Task' and lower(i.title) like '%epic%')
+            and not (i.parent_issue_type = 'Task' and lower(i.parent_title) like '%epic%')
+        then true else false
+    end as is_orphan
+```
+
+(`is_epic` and `has_epic_parent` are repeated inline inside `is_orphan` rather than referenced because DuckDB's strict static analyzer rejects forward column references in the same select list.)
+
+- [ ] **Step 3: Build fct_issues alone**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select fct_issues
+```
+
+Expected: builds clean.
+
+- [ ] **Step 4: Spot-check epic detection**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "import duckdb; con = duckdb.connect('data/fusion_issues.duckdb'); rows = con.execute(\"select issue_number, title, issue_type, is_epic from main_marts.fct_issues where is_epic order by issue_number limit 10\").fetchall(); [print(r) for r in rows]"
+```
+
+Expected: 5–20+ rows, each with `issue_type='Task'` and 'epic' (case-insensitive) somewhere in the title.
+
+- [ ] **Step 5: Spot-check orphans**
+
+```bash
+uv run python -c "import duckdb; con = duckdb.connect('data/fusion_issues.duckdb'); print(con.execute('select count(*) total, sum(is_orphan::int) orphans, sum(is_epic::int) epics, sum(has_epic_parent::int) tasks_w_epic from main_marts.fct_issues').fetchall())"
+```
+
+Expected: orphans + epics + tasks_w_epic ≈ open issues; orphans should be a non-zero but not majority count.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add transform/models/marts/fct_issues.sql
+git commit -m "Add is_epic, has_epic_parent, is_orphan to fct_issues
+
+Also passes through issue_type, milestone_state/due_on/created_at/closed_at,
+and parent_* fields. Broadens issue_category to consider native Issue Type
+alongside the EPIC/bug/enhancement labels."
+```
+
+---
+
+## Task 6: Create `marts/_schema.yml` with tests for `fct_issues`
+
+This file does not exist yet. Create it scoped to the new columns plus the existing fct_issues primary key.
+
+**Files:**
+- Create: `transform/models/marts/_schema.yml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+version: 2
+
+models:
+  - name: fct_issues
+    description: One row per GitHub issue from dbt-labs/dbt-fusion, enriched with derived metrics, classification, and parent relationship.
+    columns:
+      - name: issue_dlt_id
+        tests:
+          - unique
+          - not_null
+      - name: issue_number
+        tests:
+          - unique
+          - not_null
+      - name: issue_type
+        description: GitHub native Issue Type (Bug | Feature | Task | Epic | null)
+      - name: is_epic
+        description: True when issue_type = 'Task' and 'epic' appears in title (authoritative epic flag; preferred over the legacy label-based has_epic).
+        tests:
+          - not_null
+      - name: has_epic_parent
+        description: True when this issue's parent is an epic (parent_issue_type = 'Task' and 'epic' in parent_title).
+        tests:
+          - not_null
+      - name: is_orphan
+        description: Open issue that is neither an epic nor has an epic parent.
+        tests:
+          - not_null
+      - name: parent_number
+        description: GitHub sub-issue parent's issue number, if any.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('fct_issues')
+                field: issue_number
+              config:
+                where: "parent_number is not null"
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd transform && dbtf test --profiles-dir . --target dev --select fct_issues
+```
+
+Expected: all tests pass. The `parent_number` relationships test specifically validates that every non-null parent_number resolves to an `issue_number` in `fct_issues`. If it fails, you have cross-repo parents (rare for dbt-fusion); investigate before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add transform/models/marts/_schema.yml
+git commit -m "Add _schema.yml with tests for new fct_issues columns"
+```
+
+---
+
+## Task 7: Create `fct_epics`
+
+**Files:**
+- Create: `transform/models/marts/fct_epics.sql`
+- Modify: `transform/models/marts/_schema.yml`
+
+- [ ] **Step 1: Write `fct_epics.sql`**
+
+```sql
+with epics as (
+    select * from {{ ref('fct_issues') }}
+    where is_epic
+),
+
+child_rollup as (
+    select
+        parent_number as epic_number,
+        count(*)                                    as child_total,
+        count(*) filter (where state = 'OPEN')      as child_open,
+        count(*) filter (where state = 'CLOSED')    as child_closed
+    from {{ ref('fct_issues') }}
+    where parent_number is not null
+    group by parent_number
+)
+
+select
+    e.issue_number          as epic_number,
+    e.issue_url             as epic_url,
+    e.title,
+    e.state,
+    e.created_at,
+    e.closed_at,
+    e.milestone_number,
+    e.milestone_title,
+    e.milestone_state,
+    e.milestone_due_on,
+
+    coalesce(c.child_total,  0) as child_total,
+    coalesce(c.child_open,   0) as child_open,
+    coalesce(c.child_closed, 0) as child_closed,
+    case
+        when coalesce(c.child_total, 0) = 0 then null
+        else c.child_closed::float / c.child_total
+    end                         as pct_complete,
+
+    e.milestone_number is not null      as has_milestone,
+    case
+        when e.state = 'OPEN' and e.milestone_number is null
+        then true else false
+    end                                 as is_orphan_epic
+from epics e
+left join child_rollup c
+    on e.issue_number = c.epic_number
+```
+
+- [ ] **Step 2: Build `fct_epics`**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select fct_epics
+```
+
+Expected: builds clean.
+
+- [ ] **Step 3: Add tests to `_schema.yml`**
+
+Append to `transform/models/marts/_schema.yml`:
+
+```yaml
+  - name: fct_epics
+    description: One row per Epic (Task-typed issue with 'epic' in title), enriched with child counts and milestone attribution.
+    columns:
+      - name: epic_number
+        tests:
+          - unique
+          - not_null
+      - name: child_total
+        tests:
+          - not_null
+      - name: is_orphan_epic
+        description: Open epic with no milestone attached.
+        tests:
+          - not_null
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd transform && dbtf test --profiles-dir . --target dev --select fct_epics
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Spot-check a known epic**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "import duckdb; con = duckdb.connect('data/fusion_issues.duckdb'); rows = con.execute('select epic_number, title, child_total, child_open, child_closed, pct_complete, has_milestone from main_marts.fct_epics order by child_total desc limit 5').fetchall(); [print(r) for r in rows]"
+```
+
+Expected: a few epics with sensible child counts; `child_open + child_closed = child_total`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add transform/models/marts/fct_epics.sql transform/models/marts/_schema.yml
+git commit -m "Add fct_epics mart
+
+One row per Epic with child rollups (open/closed/total/pct_complete),
+milestone attribution, and is_orphan_epic flag for the audit layer."
+```
+
+---
+
+## Task 8: Create `fct_milestones`
+
+**Files:**
+- Create: `transform/models/marts/fct_milestones.sql`
+- Modify: `transform/models/marts/_schema.yml`
+
+- [ ] **Step 1: Write `fct_milestones.sql`**
+
+```sql
+with milestones as (
+    select * from {{ ref('dim_milestones') }}
+),
+
+issue_rollup as (
+    select
+        milestone_number,
+        count(*)                                  as total_issues,
+        count(*) filter (where state = 'OPEN')    as total_open,
+        count(*) filter (where state = 'CLOSED')  as total_closed,
+        count(*) filter (where is_epic)           as epic_count,
+        count(*) filter (where has_epic_parent)   as task_count
+    from {{ ref('fct_issues') }}
+    where milestone_number is not null
+    group by milestone_number
+)
+
+select
+    m.milestone_number,
+    m.milestone_title,
+    m.milestone_state,
+    m.milestone_due_on,
+    m.milestone_created_at,
+    m.milestone_closed_at,
+
+    coalesce(r.total_issues,  0) as total_issues,
+    coalesce(r.total_open,    0) as total_open,
+    coalesce(r.total_closed,  0) as total_closed,
+    coalesce(r.epic_count,    0) as epic_count,
+    coalesce(r.task_count,    0) as task_count,
+
+    case
+        when coalesce(r.total_issues, 0) = 0 then null
+        else r.total_closed::float / r.total_issues
+    end                          as pct_complete,
+
+    case
+        when m.milestone_state = 'OPEN'
+            and m.milestone_due_on is not null
+            and m.milestone_due_on < current_date
+        then true else false
+    end                          as is_overdue
+from milestones m
+left join issue_rollup r
+    on m.milestone_number = r.milestone_number
+```
+
+- [ ] **Step 2: Build `fct_milestones`**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select fct_milestones
+```
+
+Expected: builds clean.
+
+- [ ] **Step 3: Add tests to `_schema.yml`**
+
+Append:
+
+```yaml
+  - name: fct_milestones
+    description: One row per milestone with rollup of issues, epics, tasks, and overdue flag.
+    columns:
+      - name: milestone_number
+        tests:
+          - unique
+          - not_null
+      - name: total_issues
+        tests:
+          - not_null
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd transform && dbtf test --profiles-dir . --target dev --select fct_milestones
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add transform/models/marts/fct_milestones.sql transform/models/marts/_schema.yml
+git commit -m "Add fct_milestones mart with epic/task rollups and is_overdue"
+```
+
+---
+
+## Task 9: Audit views
+
+Three thin filters. Build all three together since they share shape.
+
+**Files:**
+- Create: `transform/models/metrics/audit_orphan_issues.sql`
+- Create: `transform/models/metrics/audit_epics_without_milestone.sql`
+- Create: `transform/models/metrics/audit_tasks_without_milestone.sql`
+
+- [ ] **Step 1: Write `audit_orphan_issues.sql`**
+
+```sql
+select
+    issue_number,
+    issue_url,
+    title,
+    issue_type,
+    state,
+    created_at,
+    (current_date - created_at::date) as age_days
+from {{ ref('fct_issues') }}
+where is_orphan
+order by created_at
+```
+
+- [ ] **Step 2: Write `audit_epics_without_milestone.sql`**
+
+```sql
+select
+    epic_number,
+    epic_url,
+    title,
+    state,
+    created_at,
+    child_total,
+    child_open
+from {{ ref('fct_epics') }}
+where is_orphan_epic
+order by created_at
+```
+
+- [ ] **Step 3: Write `audit_tasks_without_milestone.sql`**
+
+```sql
+select
+    issue_number,
+    issue_url,
+    title,
+    issue_type,
+    parent_number,
+    parent_title,
+    state,
+    created_at
+from {{ ref('fct_issues') }}
+where state = 'OPEN'
+  and has_epic_parent
+  and milestone_number is null
+order by created_at
+```
+
+- [ ] **Step 4: Build all three**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select audit_orphan_issues audit_epics_without_milestone audit_tasks_without_milestone
+```
+
+Expected: all three build clean.
+
+- [ ] **Step 5: Spot-check counts**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "import duckdb; con = duckdb.connect('data/fusion_issues.duckdb'); print('orphan_issues:', con.execute('select count(*) from main_metrics.audit_orphan_issues').fetchone()); print('orphan_epics:', con.execute('select count(*) from main_metrics.audit_epics_without_milestone').fetchone()); print('tasks_no_milestone:', con.execute('select count(*) from main_metrics.audit_tasks_without_milestone').fetchone())"
+```
+
+Expected: three counts; non-zero is normal — these audits exist precisely to surface real gaps.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add transform/models/metrics/audit_orphan_issues.sql transform/models/metrics/audit_epics_without_milestone.sql transform/models/metrics/audit_tasks_without_milestone.sql
+git commit -m "Add three audit views: orphan issues, orphan epics, tasks without milestone"
+```
+
+---
+
+## Task 10: Cross-model integrity test
+
+A singular SQL test that fails when `audit_epics_without_milestone` and `fct_epics.is_orphan_epic` disagree. dbt singular tests pass when the SELECT returns zero rows.
+
+**Files:**
+- Create: `transform/tests/audit_epics_orphan_count_matches.sql`
+
+- [ ] **Step 1: Write the test**
+
+```sql
+-- Fails when audit_epics_without_milestone rowcount disagrees with
+-- fct_epics.is_orphan_epic — i.e. the audit and the fact mart are
+-- out of sync.
+with audit_n as (
+    select count(*) as n from {{ ref('audit_epics_without_milestone') }}
+),
+fact_n as (
+    select count(*) as n from {{ ref('fct_epics') }} where is_orphan_epic
+)
+select 'mismatch' as failure, audit_n.n as audit_rowcount, fact_n.n as fact_rowcount
+from audit_n cross join fact_n
+where audit_n.n != fact_n.n
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd transform && dbtf test --profiles-dir . --target dev --select audit_epics_orphan_count_matches
+```
+
+Expected: pass (returns 0 rows).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add transform/tests/audit_epics_orphan_count_matches.sql
+git commit -m "Add singular test linking audit_epics_without_milestone to fct_epics.is_orphan_epic"
+```
+
+---
+
+## Task 11: `epic_burndown`
+
+Mirrors the date-spine technique already in `metrics/milestone_burndown.sql`. DuckDB-specific dialect (`generate_series` with `bigint`, `datediff`) is intentional and consistent with the existing burndown model.
+
+**Files:**
+- Create: `transform/models/metrics/epic_burndown.sql`
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with epic_children as (
+    select
+        e.epic_number,
+        e.title          as epic_title,
+        i.issue_number,
+        i.created_at,
+        i.closed_at
+    from {{ ref('fct_epics') }} e
+    join {{ ref('fct_issues') }} i
+        on i.parent_number = e.epic_number
+),
+
+date_spine as (
+    select
+        ((select min(created_at::date) from epic_children) + (i || ' days')::interval)::date as date_day
+    from generate_series(
+        0::bigint,
+        (select datediff('day', min(created_at::date), current_date)::bigint from epic_children)
+    ) as t(i)
+),
+
+epics as (
+    select distinct epic_number, epic_title from epic_children
+)
+
+select
+    d.date_day,
+    e.epic_number,
+    e.epic_title,
+    count(case when ec.created_at::date <= d.date_day then 1 end) as cumulative_opened,
+    count(case when ec.closed_at::date  <= d.date_day then 1 end) as cumulative_closed,
+    count(case when ec.created_at::date <= d.date_day then 1 end)
+      - count(case when ec.closed_at::date <= d.date_day then 1 end) as open_at_date
+from date_spine d
+cross join epics e
+left join epic_children ec
+    on ec.epic_number = e.epic_number
+group by d.date_day, e.epic_number, e.epic_title
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select epic_burndown
+```
+
+Expected: clean. If `generate_series` errors with a type mismatch, see the comment block in `milestone_burndown.sql` lines 18-21 — dbt-fusion strict static analysis only registers the bigint overload.
+
+- [ ] **Step 3: Spot-check**
+
+```bash
+cd /Users/dataders/Developer/fusion_issue_analysis
+uv run python -c "
+import duckdb
+con = duckdb.connect('data/fusion_issues.duckdb')
+# Most recent date for one epic should equal that epic's child_open in fct_epics.
+row = con.execute('''
+    with latest as (
+        select epic_number, max(date_day) d from main_metrics.epic_burndown group by 1
+    )
+    select b.epic_number, b.open_at_date, e.child_open
+    from latest l
+    join main_metrics.epic_burndown b on b.epic_number = l.epic_number and b.date_day = l.d
+    join main_marts.fct_epics e on e.epic_number = b.epic_number
+    where b.open_at_date != e.child_open
+    limit 5
+''').fetchall()
+print('mismatches:', row)
+"
+```
+
+Expected: empty list (latest-day burndown matches `fct_epics.child_open`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add transform/models/metrics/epic_burndown.sql
+git commit -m "Add epic_burndown reconstructing per-epic open/closed counts over time"
+```
+
+---
+
+## Task 12: Extend `milestone_burndown`
+
+Add a left join to `fct_milestones` to surface `milestone_state`, `is_overdue`, and `total_issues` alongside the existing reconstructed counts.
+
+**Files:**
+- Modify: `transform/models/metrics/milestone_burndown.sql`
+
+- [ ] **Step 1: Read the current model**
+
+Read `transform/models/metrics/milestone_burndown.sql` end-to-end. The final select is `select * from burndown where cumulative_opened > 0 order by milestone_title, date_day`.
+
+- [ ] **Step 2: Add the join**
+
+Replace the final select with:
+
+```sql
+select
+    b.*,
+    fm.milestone_state,
+    fm.is_overdue,
+    fm.total_issues
+from burndown b
+left join {{ ref('fct_milestones') }} fm
+    on b.milestone_title = fm.milestone_title
+where b.cumulative_opened > 0
+order by b.milestone_title, b.date_day
+```
+
+(`burndown` keys on `milestone_title` because that's how the existing model joins; `fct_milestones` is keyed on `milestone_number` but `milestone_title` is unique enough for this reporting layer. If duplicates surface, switch the join to `milestone_number` after extending the `burndown` CTE to carry it.)
+
+- [ ] **Step 3: Build**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target dev --select milestone_burndown
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add transform/models/metrics/milestone_burndown.sql
+git commit -m "Extend milestone_burndown with milestone_state, is_overdue, total_issues"
+```
+
+---
+
+## Task 13: Full prod-target build with strict static analysis
+
+Project policy: every model must pass `--static-analysis strict` against the prod (MotherDuck) target. This is the ship gate.
+
+**Files:** none changed.
+
+- [ ] **Step 1: Run prod build**
+
+```bash
+cd transform && dbtf build --profiles-dir . --target prod --static-analysis strict
+```
+
+Requires `MOTHERDUCK_TOKEN` env var to be set. Expected: every model builds and every test passes.
+
+If a model fails static analysis but works in dev, the most common culprits are:
+- Forward column references in the same select list (resolved by inlining — see Task 5 step 2c).
+- `generate_series` int-vs-bigint issues (already worked around in `milestone_burndown.sql` and `epic_burndown.sql`).
+
+- [ ] **Step 2: Run tests one more time as belt-and-suspenders**
+
+```bash
+cd transform && dbtf test --profiles-dir . --target prod
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: No commit — verification only**
+
+---
+
+## Task 14: Open the PR
+
+**Files:** none changed.
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/epic-task-hierarchy
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "Add epic/task hierarchy modeling" --body "$(cat <<'EOF'
+## Summary
+- Pull `issueType` and `parent` from GitHub GraphQL; plumb both through staging into `fct_issues`.
+- Add `is_epic`, `has_epic_parent`, `is_orphan` to `fct_issues`.
+- Add `fct_epics` and `fct_milestones` marts on top.
+- Add three audit views (orphan issues, epics without milestones, tasks without milestones), an `epic_burndown` model, and extend `milestone_burndown` with milestone metadata.
+
+Spec: `docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md`
+
+## Test plan
+- [ ] `dbtf build --target dev` clean
+- [ ] `dbtf build --target prod --static-analysis strict` clean
+- [ ] `dbtf test` clean (audits expected to be non-zero — that's signal, not failure)
+- [ ] Spot-check `fct_epics`: pick a known epic, confirm child counts
+- [ ] Spot-check `audit_orphan_issues`: confirm a known orphan appears
+- [ ] Spot-check `epic_burndown`: latest-day `open_at_date` equals `fct_epics.child_open`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Confirm with user**
+
+Surface the PR URL and stop. Do not merge — leave that to the user.
+
+---
+
+## Glossary of project conventions used in this plan
+
+- **`dbtf`** — dbt Fusion CLI binary (Rust engine). Use this, not `dbt-core`.
+- **Static analysis strict** — set in `transform/dbt_project.yml` flags. Failures here block prod build; works around DuckDB type coercion gaps that don't show up at runtime.
+- **`raw_source` macro** — `transform/macros/raw_source.sql`. Switches between local parquet and MotherDuck; not touched here, but referenced by `stg_issues`.
+- **`feature branches, never push directly to main`** — from `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
@@ -1,0 +1,369 @@
+# Epic / Task hierarchy modeling
+
+**Date:** 2026-05-08
+**Author:** Anders Swanson
+**Status:** Draft
+
+## Problem
+
+The current `fct_issues` model knows whether an issue has a label, an
+assignee, or a milestone, but it does not know how issues relate to one
+another. The dbt-fusion team organizes work as a two-level hierarchy:
+
+- **Epics** — top-level scoping issues, identified in this repo by
+  `issue_type = 'Task'` and `'epic'` somewhere in the title (case-insensitive).
+- **Tasks** — every other issue that lives under an epic via GitHub's
+  native sub-issue / parent-issue relationship.
+
+Without parent-child information in the warehouse we cannot answer:
+
+1. Is a given issue attached to an epic, or is it an orphan?
+2. Are there open epics that are not attributed to a milestone?
+3. How is each milestone burning down over time, broken out by epic?
+4. Are tasks consistently rolling up to epics, and do those epics
+   consistently roll up to milestones?
+
+## Definitions
+
+- **Epic.** An issue where `issue_type = 'Task'` and
+  `lower(title) LIKE '%epic%'`. Epics are a strict subset of
+  Task-typed issues — all Epics are Tasks, but not all Tasks are Epics.
+- **`has_epic_parent`.** True when an issue's parent (via GitHub
+  sub-issue relation) satisfies the Epic definition above.
+- **Task (in this design).** Any open, non-epic issue that has an
+  epic parent.
+- **Orphan issue.** An open issue that is neither an Epic nor has an
+  Epic parent.
+- **Orphan epic.** An open Epic that has no milestone attached.
+
+## Architecture overview
+
+Three changes, shipped in a single PR:
+
+1. **Extract** — pull `parent` into the GraphQL issues query so the
+   warehouse has the relationship at all.
+2. **Staging + marts** — expose parent fields, add `is_epic` and
+   `has_epic_parent` to `fct_issues`, build new `fct_epics` and
+   `fct_milestones` marts.
+3. **Audits + burndown** — three small audit models that surface the
+   integrity questions above; one new `epic_burndown` model alongside
+   the existing `milestone_burndown`.
+
+```
+extract/github/queries.py       (Phase 1)
+  └── ISSUES_QUERY: + parent { number, title, issueType { name } }
+
+transform/models/staging/
+  ├── stg_issues.sql            (Phase 2: passthrough parent_*)
+  └── _sources.yml              (Phase 1: declare new raw columns)
+
+transform/models/marts/
+  ├── fct_issues.sql            (Phase 2: + is_epic, has_epic_parent, is_orphan)
+  ├── fct_epics.sql             (Phase 2: NEW)
+  ├── fct_milestones.sql        (Phase 2: NEW)
+  └── _schema.yml               (Phase 2: tests + docs for new columns/models)
+
+transform/models/metrics/
+  ├── milestone_burndown.sql    (Phase 3: extend with fct_milestones join)
+  ├── epic_burndown.sql         (Phase 3: NEW)
+  ├── audit_orphan_issues.sql   (Phase 3: NEW)
+  ├── audit_epics_without_milestone.sql    (Phase 3: NEW)
+  └── audit_tasks_without_milestone.sql    (Phase 3: NEW)
+```
+
+## Phase 1 — Extract change
+
+### GraphQL
+
+Add to the issue node selection in
+`extract/github/queries.py:ISSUES_QUERY`:
+
+```graphql
+parent {
+  number
+  title
+  issueType { name }
+}
+```
+
+`parent` is a scalar 1:1 relationship on `Issue`. dlt's GraphQL flattening
+maps this to three new top-level columns on the `issues` resource:
+
+- `parent__number` (int, nullable)
+- `parent__title` (string, nullable)
+- `parent__issue_type__name` (string, nullable)
+
+No new dlt resource is needed — children-of-an-issue can be reconstructed
+in dbt by reverse-joining `fct_issues` on its own `parent_number`.
+
+### Source declaration
+
+Add the three columns to `transform/models/staging/_sources.yml` under
+the `issues` table so static analysis sees them.
+
+### Sanity / non-goals
+
+- We are not extracting `subIssues` from GraphQL. Reverse-join on
+  `parent_number` is sufficient and avoids redundant data.
+- We do not handle cross-repository parent links. The dbt-fusion repo
+  does not appear to use them; if `parent_number` ever fails to join
+  in `fct_issues`, the audit surface should make that visible (see
+  Test plan).
+- This change does not require a backfill — dlt's next run will pick
+  up parent relationships on all issues it loads.
+
+## Phase 2 — Staging and marts
+
+### `stg_issues`
+
+Add three passthrough columns:
+
+```sql
+parent__number       as parent_number,
+parent__title        as parent_title,
+parent__issue_type__name as parent_issue_type,
+```
+
+### `fct_issues` — new columns
+
+```sql
+-- Epic identity
+case
+  when issue_type = 'Task' and lower(title) like '%epic%'
+  then true else false
+end as is_epic,
+
+-- Parent relationship
+parent_number,
+parent_title,
+parent_issue_type,
+case
+  when parent_issue_type = 'Task' and lower(parent_title) like '%epic%'
+  then true else false
+end as has_epic_parent,
+
+-- Orphan flag — open work that doesn't roll up to an epic
+case
+  when state = 'OPEN' and not is_epic and not has_epic_parent
+  then true else false
+end as is_orphan
+```
+
+### `fct_epics` (new)
+
+**Grain:** one row per Epic.
+
+```sql
+with epics as (
+    select * from {{ ref('fct_issues') }}
+    where is_epic
+),
+
+child_rollup as (
+    select
+        parent_number as epic_number,
+        count(*)                                    as child_total,
+        count(*) filter (where state = 'OPEN')      as child_open,
+        count(*) filter (where state = 'CLOSED')    as child_closed
+    from {{ ref('fct_issues') }}
+    where parent_number is not null
+    group by parent_number
+)
+
+select
+    e.issue_number          as epic_number,
+    e.issue_url             as epic_url,
+    e.title,
+    e.state,
+    e.created_at,
+    e.closed_at,
+    e.milestone_number,
+    e.milestone_title,
+    e.milestone_due_on,
+
+    coalesce(c.child_total,  0) as child_total,
+    coalesce(c.child_open,   0) as child_open,
+    coalesce(c.child_closed, 0) as child_closed,
+    case
+        when coalesce(c.child_total, 0) = 0 then null
+        else c.child_closed::float / c.child_total
+    end                         as pct_complete,
+
+    e.milestone_number is not null      as has_milestone,
+    e.state = 'OPEN'
+        and e.milestone_number is null  as is_orphan_epic
+from epics e
+left join child_rollup c
+    on e.issue_number = c.epic_number
+```
+
+### `fct_milestones` (new)
+
+**Grain:** one row per milestone. Coexists with `dim_milestones` —
+`dim_milestones` remains the conformed dimension; `fct_milestones`
+adds aggregates.
+
+```sql
+with milestones as (
+    select * from {{ ref('dim_milestones') }}
+),
+
+issue_rollup as (
+    select
+        milestone_number,
+        count(*)                                  as total_issues,
+        count(*) filter (where state = 'OPEN')    as total_open,
+        count(*) filter (where state = 'CLOSED')  as total_closed,
+        count(*) filter (where is_epic)           as epic_count,
+        count(*) filter (where has_epic_parent)   as task_count
+    from {{ ref('fct_issues') }}
+    where milestone_number is not null
+    group by milestone_number
+)
+
+select
+    m.milestone_number,
+    m.milestone_title,
+    m.milestone_state,
+    m.milestone_due_on,
+    m.milestone_created_at,
+    m.milestone_closed_at,
+
+    coalesce(r.total_issues,  0) as total_issues,
+    coalesce(r.total_open,    0) as total_open,
+    coalesce(r.total_closed,  0) as total_closed,
+    coalesce(r.epic_count,    0) as epic_count,
+    coalesce(r.task_count,    0) as task_count,
+
+    case
+        when coalesce(r.total_issues, 0) = 0 then null
+        else r.total_closed::float / r.total_issues
+    end                          as pct_complete,
+
+    m.milestone_state = 'OPEN'
+        and m.milestone_due_on is not null
+        and m.milestone_due_on < current_date as is_overdue
+from milestones m
+left join issue_rollup r
+    on m.milestone_number = r.milestone_number
+```
+
+## Phase 3 — Audits and burndown
+
+### Audit models
+
+All three live in `transform/models/metrics/` and follow the same
+shape: a thin filter on `fct_issues` / `fct_epics` that returns the
+"violating" rows. Empty result = clean state.
+
+- **`audit_orphan_issues`** — `select … from fct_issues where is_orphan`.
+  Columns: issue_number, title, issue_type, created_at,
+  `current_date - created_at::date` as age_days.
+- **`audit_epics_without_milestone`** — `select … from fct_epics where is_orphan_epic`.
+- **`audit_tasks_without_milestone`** — open issues where
+  `has_epic_parent = true AND milestone_number IS NULL`.
+
+### `epic_burndown` (new)
+
+Same date-spine + cumulative-open/closed technique already used by
+`metrics/milestone_burndown.sql`, but pivoted on the epic's children.
+
+```sql
+with epic_children as (
+    select
+        e.epic_number,
+        e.title          as epic_title,
+        i.issue_number,
+        i.created_at,
+        i.closed_at
+    from {{ ref('fct_epics') }} e
+    join {{ ref('fct_issues') }} i
+        on i.parent_number = e.epic_number
+),
+
+date_spine as (
+    select
+        ((select min(created_at::date) from epic_children) + (i || ' days')::interval)::date as date_day
+    from generate_series(
+        0::bigint,
+        (select datediff('day', min(created_at::date), current_date)::bigint from epic_children)
+    ) as t(i)
+),
+
+epics as (
+    select distinct epic_number, epic_title from epic_children
+)
+
+select
+    d.date_day,
+    e.epic_number,
+    e.epic_title,
+    count(case when ec.created_at::date <= d.date_day then 1 end) as cumulative_opened,
+    count(case when ec.closed_at::date  <= d.date_day then 1 end) as cumulative_closed,
+    count(case when ec.created_at::date <= d.date_day then 1 end)
+      - count(case when ec.closed_at::date <= d.date_day then 1 end) as open_at_date
+from date_spine d
+cross join epics e
+left join epic_children ec
+    on ec.epic_number = e.epic_number
+group by d.date_day, e.epic_number, e.epic_title
+```
+
+### `milestone_burndown` extension
+
+Add a left join to `fct_milestones` to surface `milestone_state`,
+`is_overdue`, and `total_issues` alongside the existing reconstructed
+counts. No re-architecture.
+
+## Tests
+
+In `_schema.yml`:
+
+- `fct_issues.is_epic` — not null.
+- `fct_issues.has_epic_parent` — not null.
+- `fct_issues.is_orphan` — not null.
+- `fct_issues.parent_number` — `relationships` test to
+  `ref('fct_issues')` field `issue_number`, scoped to rows where
+  `parent_number is not null` (this is the cross-repo / data-quality
+  guardrail: a parent_number that does not match an issue in the
+  warehouse means either cross-repo or a bug).
+- `fct_epics.epic_number` — unique, not null.
+- `fct_milestones.milestone_number` — unique, not null.
+- Audit models — `dbt_utils.equal_rowcount` to `0` configured as
+  `severity: warn` so audits surface in CI logs without breaking the
+  build (failing audits are signal, not bugs in the pipeline).
+
+All new models must pass
+`dbtf build --profiles-dir . --target prod --static-analysis strict`
+per project convention.
+
+## Test plan
+
+- [ ] Run extract against dbt-fusion; confirm `parent__number`,
+      `parent__title`, `parent__issue_type__name` populated for at
+      least some issues.
+- [ ] `dbtf build --target dev` clean.
+- [ ] `dbtf build --target prod --static-analysis strict` clean.
+- [ ] `dbtf test` clean (audit warnings allowed).
+- [ ] Spot-check `fct_epics`: pick one known epic, verify
+      `child_total` / `child_open` / `child_closed` match the count of
+      issues whose `parent_number` equals it.
+- [ ] Spot-check `audit_orphan_issues`: pick a known orphan, confirm
+      it appears.
+- [ ] Spot-check `audit_epics_without_milestone`: confirm at least one
+      known orphan epic appears (or zero, with rationale).
+- [ ] `epic_burndown`: pick one epic, eyeball that
+      `cumulative_opened - cumulative_closed = open_at_date` for the
+      latest date and matches `child_open` in `fct_epics`.
+
+## Non-goals
+
+- No dlt snapshot strategy. Burndown is reconstructed from
+  `created_at` / `closed_at`; if an issue is reopened, the historical
+  reconstruction will be inaccurate for the period between close and
+  reopen. Acceptable for current use.
+- No cross-repository parent handling. Surfaced via the
+  `relationships` test on `parent_number`.
+- No backfill of historical issues beyond what dlt's next run pulls.
+- No changes to dashboards in this PR — that is a follow-up once the
+  marts are stable.

--- a/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
@@ -4,26 +4,37 @@
 **Author:** Anders Swanson
 **Status:** Draft
 
-## Prerequisites
+## Phase 0 — Plumb `issue_type` end-to-end
 
-This spec assumes the `feat/categorize-with-issue-type` branch
-(commits `1db7750d` "Pull GitHub Issue Type into stg_issues" and
-`c2c61666` "Use GitHub Issue Type in issue_category") has merged to
-`main`. That branch:
+The Epic definition relies on `issue_type = 'Task'`. As of writing,
+`issue_type` is not yet on `main` — it lives on the unmerged
+`feat/categorize-with-issue-type` branch (commits `1db7750d` and
+`c2c61666`). Rather than waiting on that branch, this spec absorbs
+those changes as Phase 0 so the work is self-contained.
 
-- Adds `issueType { name }` to `extract/github/queries.py:ISSUES_QUERY`
-  (guarded by inline-fragment-style template substitution because the
-  same query body is reused for pull requests where `issueType` is
-  unavailable).
-- Adds `issue_type__name as issue_type` passthrough to `stg_issues.sql`
-  and declares it under `_sources.yml`.
-- Surfaces `issue_type` on `fct_issues` and folds it into
-  `issue_category`, and creates `transform/models/marts/_schema.yml`.
+If `grep -r issue_type extract/github/ transform/models/` returns
+non-empty when implementation begins, Phase 0 is already done — skip
+it. Otherwise, do all of the following before Phase 1:
 
-If that branch has not merged when this work begins, this spec's
-implementation plan must absorb those changes as a Phase 0. Verify
-before starting: `grep -r issue_type extract/github/ transform/models/`
-should return non-empty.
+- **Extract** — add `issueType { name }` to the issue node selection
+  in `extract/github/queries.py:ISSUES_QUERY`. The same query body is
+  reused for `pullRequests`, where `issueType` is not a valid field.
+  Guard with the existing `%s` template substitution pattern (or an
+  inline-fragment workaround) so the issues-only field is only
+  emitted when the query targets `issues`.
+- **Source** — declare `issue_type__name` under the `issues` table in
+  `transform/models/staging/_sources.yml`.
+- **Staging** — in `stg_issues.sql`, select
+  `issue_type__name as issue_type`.
+- **Marts** — in `fct_issues.sql`, passthrough `i.issue_type`. Update
+  the existing `issue_category` CASE to consider `issue_type`
+  alongside the label flags (so issues with native Issue Type but no
+  matching label stop falling through to `'other'`). Create
+  `transform/models/marts/_schema.yml` if it doesn't exist and
+  document the new column.
+
+This Phase 0 mirrors the unmerged branch's intent. After it lands,
+Phases 1–3 below proceed unchanged.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-05-08-epic-task-hierarchy-design.md
@@ -4,6 +4,27 @@
 **Author:** Anders Swanson
 **Status:** Draft
 
+## Prerequisites
+
+This spec assumes the `feat/categorize-with-issue-type` branch
+(commits `1db7750d` "Pull GitHub Issue Type into stg_issues" and
+`c2c61666` "Use GitHub Issue Type in issue_category") has merged to
+`main`. That branch:
+
+- Adds `issueType { name }` to `extract/github/queries.py:ISSUES_QUERY`
+  (guarded by inline-fragment-style template substitution because the
+  same query body is reused for pull requests where `issueType` is
+  unavailable).
+- Adds `issue_type__name as issue_type` passthrough to `stg_issues.sql`
+  and declares it under `_sources.yml`.
+- Surfaces `issue_type` on `fct_issues` and folds it into
+  `issue_category`, and creates `transform/models/marts/_schema.yml`.
+
+If that branch has not merged when this work begins, this spec's
+implementation plan must absorb those changes as a Phase 0. Verify
+before starting: `grep -r issue_type extract/github/ transform/models/`
+should return non-empty.
+
 ## Problem
 
 The current `fct_issues` model knows whether an issue has a label, an
@@ -28,6 +49,22 @@ Without parent-child information in the warehouse we cannot answer:
 - **Epic.** An issue where `issue_type = 'Task'` and
   `lower(title) LIKE '%epic%'`. Epics are a strict subset of
   Task-typed issues — all Epics are Tasks, but not all Tasks are Epics.
+  Note: `is_epic` does not gate on state — both open and closed Epics
+  qualify, so historical reporting and burndown can include closed
+  Epics.
+
+### Naming reconciliation: `is_epic` vs existing `has_epic`
+
+`fct_issues` currently has `has_epic` (0/1 flag, true when an issue
+carries the `EPIC` label) and `issue_category` (string with `'epic'`
+as one value). These are **label-based**.
+
+The new `is_epic` is **issue-type + title based** and is the
+authoritative epic flag going forward — the dbt-fusion team has moved
+off the `EPIC` label and onto native Issue Types with title
+conventions. Keep `has_epic` as-is for now (some dashboards may still
+read it) but document in `_schema.yml` that `is_epic` is preferred.
+Removing `has_epic` is a separate cleanup, out of scope here.
 - **`has_epic_parent`.** True when an issue's parent (via GitHub
   sub-issue relation) satisfies the Epic definition above.
 - **Task (in this design).** Any open, non-epic issue that has an
@@ -126,14 +163,17 @@ parent__issue_type__name as parent_issue_type,
 
 ### `fct_issues` — new columns
 
+The prereq branch already exposes `issue_type` (passthrough from
+`stg_issues`). On top of that, this spec adds:
+
 ```sql
--- Epic identity
+-- Epic identity (issue_type + title; authoritative going forward)
 case
   when issue_type = 'Task' and lower(title) like '%epic%'
   then true else false
 end as is_epic,
 
--- Parent relationship
+-- Parent relationship (passthroughs from stg_issues)
 parent_number,
 parent_title,
 parent_issue_type,
@@ -148,6 +188,19 @@ case
   then true else false
 end as is_orphan
 ```
+
+`fct_issues` should also expose enriched milestone columns so
+downstream marts (`fct_epics`, audits, burndown) don't need to
+re-join `dim_milestones`. Add these passthroughs:
+
+```sql
+i.milestone_state,
+i.milestone_due_on,
+i.milestone_created_at,
+i.milestone_closed_at,
+```
+
+(`stg_issues` already selects all four from the source.)
 
 ### `fct_epics` (new)
 
@@ -262,6 +315,10 @@ shape: a thin filter on `fct_issues` / `fct_epics` that returns the
 - **`audit_epics_without_milestone`** — `select … from fct_epics where is_orphan_epic`.
 - **`audit_tasks_without_milestone`** — open issues where
   `has_epic_parent = true AND milestone_number IS NULL`.
+
+Sanity test: `audit_epics_without_milestone` row count should equal
+`count(*) filter (where is_orphan_epic)` from `fct_epics`. Encode as
+a `dbt_utils.equal_rowcount` test or equivalent.
 
 ### `epic_burndown` (new)
 

--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -86,7 +86,14 @@ def get_reactions_data(
         "node_type": node_type,
     }
     issue_type_fragment = (
-        "issueType { name }" if node_type == "issues" else ""
+        """issueType { name }
+        parent {
+          number
+          title
+          issueType { name }
+        }"""
+        if node_type == "issues"
+        else ""
     )
     query = (ISSUES_QUERY % node_type).replace(
         "__ISSUE_TYPE_FRAGMENT__", issue_type_fragment

--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -5,7 +5,13 @@ from dlt.common.typing import DictStrAny, StrAny
 from dlt.common.utils import chunks
 from dlt.sources.helpers import requests
 
-from .queries import COMMENT_REACTIONS_QUERY, ISSUES_QUERY, STARGAZERS_QUERY, RATE_LIMIT
+from .queries import (
+    COMMENT_REACTIONS_QUERY,
+    ISSUE_ONLY_FIELDS,
+    ISSUES_QUERY,
+    STARGAZERS_QUERY,
+    RATE_LIMIT,
+)
 from .settings import GRAPHQL_API_BASE_URL, REST_API_BASE_URL
 
 MAX_RETRIES = 5
@@ -85,19 +91,10 @@ def get_reactions_data(
         "first_timeline_items": 50,
         "node_type": node_type,
     }
-    issue_type_fragment = (
-        """issueType { name }
-        parent {
-          number
-          title
-          issueType { name }
-        }"""
-        if node_type == "issues"
-        else ""
-    )
-    query = (ISSUES_QUERY % node_type).replace(
-        "__ISSUE_TYPE_FRAGMENT__", issue_type_fragment
-    )
+    # `issueType` and `parent` are only valid on the Issue type; they would
+    # cause a GraphQL validation error if included in the pullRequests body.
+    issue_only_fields = ISSUE_ONLY_FIELDS if node_type == "issues" else ""
+    query = ISSUES_QUERY % (node_type, issue_only_fields)
     for page_items in _get_graphql_pages(
         access_token, query, variables, node_type, max_items
     ):

--- a/extract/github/queries.py
+++ b/extract/github/queries.py
@@ -7,6 +7,15 @@ RATE_LIMIT = """
   }
 """
 
+ISSUE_ONLY_FIELDS = """
+        issueType { name }
+        parent {
+          number
+          title
+          issueType { name }
+        }
+"""
+
 ISSUES_QUERY = """
 query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions: Int!, $first_comments: Int!, $first_timeline_items: Int!, $page_after: String) {
   repository(owner: $owner, name: $name) {
@@ -29,7 +38,7 @@ query($owner: String!, $name: String!, $issues_per_page: Int!, $first_reactions:
         createdAt
         state
         updatedAt
-        __ISSUE_TYPE_FRAGMENT__
+        %s
         labels(first: 25) {
           nodes {
             name

--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -177,7 +177,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['bug', 'enhancement', 'other']
+                values: ['bug', 'enhancement', 'other', 'task']
       - name: age_days
         tests:
           - not_null
@@ -252,7 +252,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['bug', 'enhancement', 'other', 'epic']
+                values: ['bug', 'enhancement', 'other', 'epic', 'task']
 
   - name: open_by_category
     description: Open issue count per category

--- a/transform/models/marts/_schema.yml
+++ b/transform/models/marts/_schema.yml
@@ -3,8 +3,8 @@ version: 2
 models:
   - name: fct_issues
     description: >
-      One row per GitHub issue with derived metrics (time-to-close, time-to-first-response),
-      label-derived flags, and a coarse `issue_category` classification.
+      One row per GitHub issue with derived metrics, issue-type classification,
+      and parent hierarchy fields for epic/task rollups.
     columns:
       - name: issue_dlt_id
         tests:
@@ -27,14 +27,33 @@ models:
           or for repos that don't use Issue Types.
       - name: issue_category
         description: >
-          Coarse bucket — 'bug', 'enhancement', 'epic', or 'other'.
-          Resolved by combining label-derived flags (`bug` / `enhancement` / `EPIC`)
-          with GitHub's native Issue Type ('Bug' / 'Feature' / 'Epic').
-          'Feature' and 'Enhancement' Issue Types both map to 'enhancement'.
-          Issues with Issue Type 'Task' (or any unrecognized type) without a
-          matching label fall into 'other'.
+          Coarse bucket resolved by combining label-derived flags with GitHub's
+          native Issue Type. Task-typed issues without a stronger label map to
+          'task'.
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ['bug', 'enhancement', 'epic', 'other']
+                values: ['bug', 'enhancement', 'epic', 'task', 'other']
+      - name: is_epic
+        description: True when issue_type = 'Task' and 'epic' appears in title (authoritative epic flag; preferred over the legacy label-based has_epic).
+        tests:
+          - not_null
+      - name: has_epic_parent
+        description: True when this issue's parent is an epic (parent_issue_type = 'Task' and 'epic' in parent_title).
+        tests:
+          - not_null
+      - name: is_orphan
+        description: Open issue that is neither an epic nor has an epic parent.
+        tests:
+          - not_null
+      - name: parent_number
+        description: GitHub sub-issue parent's issue number, if any.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('fct_issues')
+                field: issue_number
+              config:
+                where: "parent_number is not null"
+                severity: warn  # parent may be cross-repo or pre-extract; warn rather than block

--- a/transform/models/marts/_schema.yml
+++ b/transform/models/marts/_schema.yml
@@ -57,3 +57,18 @@ models:
               config:
                 where: "parent_number is not null"
                 severity: warn  # parent may be cross-repo or pre-extract; warn rather than block
+
+  - name: fct_epics
+    description: One row per Epic (Task-typed issue with 'epic' in title), enriched with child counts and milestone attribution.
+    columns:
+      - name: epic_number
+        tests:
+          - unique
+          - not_null
+      - name: child_total
+        tests:
+          - not_null
+      - name: is_orphan_epic
+        description: Open epic with no milestone attached.
+        tests:
+          - not_null

--- a/transform/models/marts/_schema.yml
+++ b/transform/models/marts/_schema.yml
@@ -72,3 +72,14 @@ models:
         description: Open epic with no milestone attached.
         tests:
           - not_null
+
+  - name: fct_milestones
+    description: One row per milestone with rollup of issues, epics, tasks, and overdue flag.
+    columns:
+      - name: milestone_number
+        tests:
+          - unique
+          - not_null
+      - name: total_issues
+        tests:
+          - not_null

--- a/transform/models/marts/fct_epics.sql
+++ b/transform/models/marts/fct_epics.sql
@@ -1,0 +1,44 @@
+with epics as (
+    select * from {{ ref('fct_issues') }}
+    where is_epic
+),
+
+child_rollup as (
+    select
+        parent_number as epic_number,
+        count(*)                                    as child_total,
+        count(*) filter (where state = 'OPEN')      as child_open,
+        count(*) filter (where state = 'CLOSED')    as child_closed
+    from {{ ref('fct_issues') }}
+    where parent_number is not null
+    group by parent_number
+)
+
+select
+    e.issue_number          as epic_number,
+    e.issue_url             as epic_url,
+    e.title,
+    e.state,
+    e.created_at,
+    e.closed_at,
+    e.milestone_number,
+    e.milestone_title,
+    e.milestone_state,
+    e.milestone_due_on,
+
+    coalesce(c.child_total,  0) as child_total,
+    coalesce(c.child_open,   0) as child_open,
+    coalesce(c.child_closed, 0) as child_closed,
+    case
+        when coalesce(c.child_total, 0) = 0 then null
+        else c.child_closed::float / c.child_total
+    end                         as pct_complete,
+
+    e.milestone_number is not null      as has_milestone,
+    case
+        when e.state = 'OPEN' and e.milestone_number is null
+        then true else false
+    end                                 as is_orphan_epic
+from epics e
+left join child_rollup c
+    on e.issue_number = c.epic_number

--- a/transform/models/marts/fct_issues.sql
+++ b/transform/models/marts/fct_issues.sql
@@ -50,9 +50,16 @@ select
     i.closed,
     i.author_login,
     i.author_association,
-    i.issue_type,
     i.milestone_number,
     i.milestone_title,
+    i.issue_type,
+    i.milestone_state,
+    i.milestone_due_on,
+    i.milestone_created_at,
+    i.milestone_closed_at,
+    i.parent_number,
+    i.parent_title,
+    i.parent_issue_type,
     i.reactions_total_count,
     i.comments_total_count,
     i.created_at,
@@ -83,6 +90,7 @@ select
         when il.has_epic = 1 or i.issue_type = 'Epic' then 'epic'
         when il.has_bug = 1 or i.issue_type = 'Bug' then 'bug'
         when il.has_enhancement = 1 or i.issue_type in ('Feature', 'Enhancement') then 'enhancement'
+        when i.issue_type = 'Task' then 'task'
         else 'other'
     end as issue_category,
 
@@ -95,6 +103,20 @@ select
     case when coalesce(il.label_count, 0) > 0 then true else false end as is_labeled,
     case when coalesce(ti.assignee_count, 0) > 0 then true else false end as is_assigned,
     case when i.milestone_number is not null then true else false end as has_milestone
+    ,case
+        when i.issue_type = 'Task' and lower(i.title) like '%epic%'
+        then true else false
+    end as is_epic
+    ,case
+        when i.parent_issue_type = 'Task' and lower(i.parent_title) like '%epic%'
+        then true else false
+    end as has_epic_parent
+    ,case
+        when i.state = 'OPEN'
+            and not coalesce(i.issue_type = 'Task' and lower(i.title) like '%epic%', false)
+            and not coalesce(i.parent_issue_type = 'Task' and lower(i.parent_title) like '%epic%', false)
+        then true else false
+    end as is_orphan
 
 from issues i
 left join first_comments fc

--- a/transform/models/marts/fct_milestones.sql
+++ b/transform/models/marts/fct_milestones.sql
@@ -37,7 +37,7 @@ select
     case
         when m.milestone_state = 'OPEN'
             and m.milestone_due_on is not null
-            and m.milestone_due_on < current_date
+            and m.milestone_due_on::date < current_date
         then true else false
     end                          as is_overdue
 from milestones m

--- a/transform/models/marts/fct_milestones.sql
+++ b/transform/models/marts/fct_milestones.sql
@@ -1,0 +1,45 @@
+with milestones as (
+    select * from {{ ref('dim_milestones') }}
+),
+
+issue_rollup as (
+    select
+        milestone_number,
+        count(*)                                  as total_issues,
+        count(*) filter (where state = 'OPEN')    as total_open,
+        count(*) filter (where state = 'CLOSED')  as total_closed,
+        count(*) filter (where is_epic)           as epic_count,
+        count(*) filter (where has_epic_parent)   as task_count
+    from {{ ref('fct_issues') }}
+    where milestone_number is not null
+    group by milestone_number
+)
+
+select
+    m.milestone_number,
+    m.milestone_title,
+    m.milestone_state,
+    m.milestone_due_on,
+    m.milestone_created_at,
+    m.milestone_closed_at,
+
+    coalesce(r.total_issues,  0) as total_issues,
+    coalesce(r.total_open,    0) as total_open,
+    coalesce(r.total_closed,  0) as total_closed,
+    coalesce(r.epic_count,    0) as epic_count,
+    coalesce(r.task_count,    0) as task_count,
+
+    case
+        when coalesce(r.total_issues, 0) = 0 then null
+        else r.total_closed::float / r.total_issues
+    end                          as pct_complete,
+
+    case
+        when m.milestone_state = 'OPEN'
+            and m.milestone_due_on is not null
+            and m.milestone_due_on < current_date
+        then true else false
+    end                          as is_overdue
+from milestones m
+left join issue_rollup r
+    on m.milestone_number = r.milestone_number

--- a/transform/models/metrics/audit_epics_without_milestone.sql
+++ b/transform/models/metrics/audit_epics_without_milestone.sql
@@ -1,0 +1,11 @@
+select
+    epic_number,
+    epic_url,
+    title,
+    state,
+    created_at,
+    child_total,
+    child_open
+from {{ ref('fct_epics') }}
+where is_orphan_epic
+order by created_at

--- a/transform/models/metrics/audit_orphan_issues.sql
+++ b/transform/models/metrics/audit_orphan_issues.sql
@@ -1,0 +1,11 @@
+select
+    issue_number,
+    issue_url,
+    title,
+    issue_type,
+    state,
+    created_at,
+    (current_date - created_at::date) as age_days
+from {{ ref('fct_issues') }}
+where is_orphan
+order by created_at

--- a/transform/models/metrics/audit_tasks_without_milestone.sql
+++ b/transform/models/metrics/audit_tasks_without_milestone.sql
@@ -1,0 +1,14 @@
+select
+    issue_number,
+    issue_url,
+    title,
+    issue_type,
+    parent_number,
+    parent_title,
+    state,
+    created_at
+from {{ ref('fct_issues') }}
+where state = 'OPEN'
+  and has_epic_parent
+  and milestone_number is null
+order by created_at

--- a/transform/models/metrics/epic_burndown.sql
+++ b/transform/models/metrics/epic_burndown.sql
@@ -1,0 +1,38 @@
+with epic_children as (
+    select
+        e.epic_number,
+        e.title as epic_title,
+        i.issue_number,
+        i.created_at,
+        i.closed_at
+    from {{ ref('fct_epics') }} e
+    join {{ ref('fct_issues') }} i
+        on i.parent_number = e.epic_number
+),
+
+date_spine as (
+    select
+        ((select min(created_at::date) from epic_children) + (i || ' days')::interval)::date as date_day
+    from generate_series(
+        0::bigint,
+        (select datediff('day', min(created_at::date), current_date)::bigint from epic_children)
+    ) as t(i)
+),
+
+epics as (
+    select distinct epic_number, epic_title from epic_children
+)
+
+select
+    d.date_day,
+    e.epic_number,
+    e.epic_title,
+    count(case when ec.created_at::date <= d.date_day then 1 end) as cumulative_opened,
+    count(case when ec.closed_at::date <= d.date_day then 1 end) as cumulative_closed,
+    count(case when ec.created_at::date <= d.date_day then 1 end)
+        - count(case when ec.closed_at::date <= d.date_day then 1 end) as open_at_date
+from date_spine d
+cross join epics e
+left join epic_children ec
+    on ec.epic_number = e.epic_number
+group by d.date_day, e.epic_number, e.epic_title

--- a/transform/models/metrics/milestone_burndown.sql
+++ b/transform/models/metrics/milestone_burndown.sql
@@ -46,6 +46,13 @@ burndown as (
     group by d.date_day, ms.milestone_title, ms.milestone_due_on
 )
 
-select * from burndown
-where cumulative_opened > 0
-order by milestone_title, date_day
+select
+    b.*,
+    fm.milestone_state,
+    fm.is_overdue,
+    fm.total_issues
+from burndown b
+left join {{ ref('fct_milestones') }} fm
+    on b.milestone_title = fm.milestone_title
+where b.cumulative_opened > 0
+order by b.milestone_title, b.date_day

--- a/transform/models/staging/_sources.yml
+++ b/transform/models/staging/_sources.yml
@@ -5,6 +5,18 @@ sources:
     description: >
       Raw GitHub issue data extracted via dlt from dbt-labs/dbt-fusion.
       Parquet files in data/raw/fusion_issues/. Gitignored — run extract/run.py to populate.
+    tables:
+      - name: issues
+        description: Raw issues from dlt GraphQL extract (flattened nested fields use double-underscore separators).
+        columns:
+          - name: issue_type__name
+            description: GitHub native Issue Type (Bug | Feature | Task | Epic | null)
+          - name: parent__number
+            description: Parent issue number via GitHub sub-issues
+          - name: parent__title
+            description: Parent issue title
+          - name: parent__issue_type__name
+            description: Parent issue's native Issue Type
 models:
   - name: stg_issues
     description: Cleaned issues from dbt-labs/dbt-fusion

--- a/transform/models/staging/stg_issues.sql
+++ b/transform/models/staging/stg_issues.sql
@@ -26,7 +26,11 @@ renamed as (
         comments_total_count,
         created_at,
         updated_at,
-        closed_at
+        closed_at,
+        issue_type__name as issue_type,
+        parent__number as parent_number,
+        parent__title as parent_title,
+        parent__issue_type__name as parent_issue_type
     from source
 )
 

--- a/transform/tests/audit_epics_orphan_count_matches.sql
+++ b/transform/tests/audit_epics_orphan_count_matches.sql
@@ -1,0 +1,11 @@
+-- Fails when audit_epics_without_milestone rowcount disagrees with
+-- fct_epics.is_orphan_epic, which means the audit and mart drifted.
+with audit_n as (
+    select count(*) as n from {{ ref('audit_epics_without_milestone') }}
+),
+fact_n as (
+    select count(*) as n from {{ ref('fct_epics') }} where is_orphan_epic
+)
+select 'mismatch' as failure, audit_n.n as audit_rowcount, fact_n.n as fact_rowcount
+from audit_n cross join fact_n
+where audit_n.n != fact_n.n


### PR DESCRIPTION
## Summary
- Pull GitHub issue type and parent fields through extraction, staging, and fct_issues.
- Add epic/task hierarchy marts: fct_epics and fct_milestones.
- Add hierarchy audits, an orphan-epic integrity test, epic_burndown, and milestone burndown rollups.

## Notes
- Refreshed local parquet and MotherDuck raw_github.issues so parent fields are available for validation.
- The parent_number relationship remains warn-level because some parents can be cross-repo or outside the extract window.

## Validation
- /Users/dataders/.local/bin/dbt build --profiles-dir . --target dev
- /Users/dataders/.local/bin/dbt build --profiles-dir . --target prod --static-analysis strict
- /Users/dataders/.local/bin/dbt test --profiles-dir . --target prod
- audit counts spot-check: orphan_issues=179, orphan_epics=6, tasks_no_milestone=148
- epic_burndown spot-check: latest-day open_at_date matches fct_epics.child_open

Generated from the Claude Code implementation plan in docs/superpowers/plans/2026-05-08-epic-task-hierarchy.md.