### PR TITLE
Add Playwright UI tests for dashboard bakeoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'package-lock.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-dashboard-npm-
 
       - name: Install dependencies
         run: uv sync --dev
+
+      - name: Install root npm dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Install Playwright browsers
+        if: github.actor != 'dependabot[bot]'
+        run: npx playwright install --with-deps chromium
 
       - name: Install DAC
         run: |
@@ -74,10 +81,10 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
         run: |
-          uv run prefab export dashboard/prefab/app.py -o /tmp/prefab_app.html
-          uv run prefab export dashboard/prefab/app_reactive.py -o /tmp/prefab_app_reactive.html
-          uv run prefab export dashboard/prefab/app_myspace.py -o /tmp/prefab_myspace.html
-          uv run prefab export dashboard/prefab/app_windows_2000.py -o /tmp/prefab_windows_2000.html
+          uv run prefab export dashboard/prefab/app.py -o dashboard/prefab/app.html
+          uv run prefab export dashboard/prefab/app_reactive.py -o dashboard/prefab/app_reactive.html
+          uv run prefab export dashboard/prefab/app_myspace.py -o dashboard/prefab/app_myspace.html
+          uv run prefab export dashboard/prefab/app_windows_2000.py -o dashboard/prefab/app_windows_2000.html
 
       - name: Smoke-test npm dashboards
         if: github.actor != 'dependabot[bot]'
@@ -97,7 +104,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o /tmp/marimo.html
+        run: uv run marimo export html --no-include-code dashboard/marimo/app.py -o dashboard/marimo.html
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -116,7 +123,19 @@ jobs:
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           DAC_ENVIRONMENT: prod
-          DAC_OUTPUT: /tmp/dac-build
+          DAC_OUTPUT: dashboard/dac/build
         run: |
           uv run python3 dashboard/dac/render.py
-          ! grep -q 'bruin query failed' /tmp/dac-build/index.html
+          ! grep -q 'bruin query failed' dashboard/dac/build/index.html
+
+      - name: Run Playwright UI tests
+        if: github.actor != 'dependabot[bot]'
+        run: npm run test:ui
+
+      - name: Upload Playwright report
+        if: always() && github.actor != 'dependabot[bot]'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        if: github.actor != 'dependabot[bot]'
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       # ── Dashboard smoke-test (all frameworks, no || true) ─────────────────
       # Data comes from MotherDuck — extract.yml keeps it fresh 4x/day.
       # No extract or dbt build here; those run in extract.yml on schedule

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  MDV_SHA: b9d5a8c1bb66b094a8745775cb9bf1389f08403f
+
 on:
   pull_request:
   push:
@@ -24,6 +27,14 @@ jobs:
           key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'package-lock.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-dashboard-npm-
+
+      - name: Cache MDV build
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/fusion-mdv-cache
+          key: ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-${{ hashFiles('dashboard/mdv/build.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-mdv-${{ env.MDV_SHA }}-
 
       - name: Install dependencies
         run: uv sync --dev
@@ -99,6 +110,13 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
           FUSION_DB: md:fusion_issues
         run: uv run dashboard/ggsql/build.py
+
+      - name: Smoke-test MDV
+        if: github.actor != 'dependabot[bot]'
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          MDV_CACHE_DIR: ${{ runner.temp }}/fusion-mdv-cache/mdv-${{ env.MDV_SHA }}
+        run: bash dashboard/mdv/build.sh
 
       - name: Smoke-test Marimo
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       - name: Export Prefab dashboards
         id: prefab
         continue-on-error: true

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'dashboard/**'
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/deploy-dashboard.yml'
   # Run daily at 6am UTC
   schedule:
@@ -42,7 +43,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'package-lock.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-dashboard-npm-
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        if: github.actor != 'dependabot[bot]'
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       # Data comes from MotherDuck — no extract or dbt build needed.
 
       - name: Export Prefab dashboards
@@ -65,6 +71,7 @@ jobs:
           mkdir -p preview/prefab
           cp dashboard/index.html preview/index.html
           cp dashboard/about.html preview/about.html
+          cp dashboard/data_freshness.json preview/data_freshness.json
           mkdir -p preview/shaper
           cp dashboard/shaper/index.html preview/shaper/index.html
           cp dashboard/shaper/fusion-issue-health.dashboard.sql preview/shaper/fusion-issue-health.dashboard.sql

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
+          key: ${{ runner.os }}-dashboard-npm-${{ hashFiles('package.json', 'package-lock.json', 'dashboard/observable/package-lock.json', 'dashboard/evidence/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-dashboard-npm-
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+playwright-report/
+test-results/
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ dashboard/observable/node_modules/
 
 # Dashboard build artifacts (index.html is the bakeoff wrapper, tracked in git)
 dashboard/about.html
+dashboard/data_freshness.json
 dashboard/app.html
 dashboard/app_myspace.html
 dashboard/prefab/app.html
@@ -196,7 +197,7 @@ dashboard/dac/build/
 logs/queries
 
 # Claude Code session state
-.claude/scheduled_tasks.lock
+.claude/
 
 # Git worktrees
 .worktrees/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
+.PHONY: serve build ui-test about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -13,6 +13,10 @@ serve: build kill-server
 
 ## build        Build every dashboard's static output (no serve)
 build: about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
+
+## ui-test      Run Playwright checks against generated dashboard exports
+ui-test:
+	npm run test:ui
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build ui-test about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
+.PHONY: serve build ui-test data-freshness about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,11 +12,15 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
+build: data-freshness about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
 
 ## ui-test      Run Playwright checks against generated dashboard exports
 ui-test:
 	npm run test:ui
+
+## data-freshness Write source-data freshness metadata for the dashboard chrome
+data-freshness:
+	uv run python dashboard/write_data_freshness.py
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -91,6 +95,7 @@ kill-server:
 ## clean        Remove all generated dashboard files
 clean:
 	rm -f  dashboard/prefab/app.html dashboard/prefab/app_reactive.html dashboard/prefab/app_myspace.html dashboard/prefab/app_windows_2000.html
+	rm -f  dashboard/data_freshness.json
 	rm -f  dashboard/ggsql/index.html dashboard/mviz/index.html dashboard/mdv/index.html dashboard/marimo.html
 	rm -rf dashboard/mviz/data dashboard/mdv/data dashboard/observable/dist dashboard/evidence/build
 	rm -f  dashboard/quarto/index.html

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Common commands:
 make extract
 make dbt
 make build
+make ui-test
 make serve
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `make extract`: pull GitHub issue data with dlt
 - `make dbt`: build shared models in DuckDB
 - `make build`: export all dashboard variants
+- `make ui-test`: run Playwright checks against the generated dashboard exports
 - `make serve`: build and open local static wrapper
 
 Dashboard variants include Prefab, ggsql + Vega-Lite, mviz, MDV, Observable, Evidence.dev, Marimo, Quarto, and DAC.

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -23,13 +23,59 @@
       border-bottom: 1px solid #333;
     }
 
+    .chrome-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 10px;
+      min-width: 0;
+    }
+
     .header-title {
       font-size: 0.78rem;
       font-weight: 400;
       color: #666;
       letter-spacing: 0.04em;
       text-transform: uppercase;
-      margin-bottom: 10px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chrome-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex: 0 0 auto;
+      color: #777;
+      font-size: 0.76rem;
+      white-space: nowrap;
+    }
+
+    .repo-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border: 1px solid #2d2d2d;
+      border-radius: 4px;
+      background: #1a1a1a;
+      opacity: 0.76;
+      transition: opacity 0.1s, border-color 0.1s;
+    }
+
+    .repo-link:hover,
+    .repo-link:focus-visible {
+      border-color: #666;
+      opacity: 1;
+    }
+
+    .repo-link img {
+      width: 16px;
+      height: 16px;
     }
 
     nav {
@@ -109,12 +155,52 @@
       border: none;
       background: #fff;
     }
+
+    @media (max-width: 720px) {
+      header {
+        padding-right: 12px;
+        padding-left: 12px;
+      }
+
+      .chrome-bar {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .header-title {
+        white-space: normal;
+      }
+
+      .chrome-meta {
+        font-size: 0.72rem;
+      }
+    }
   </style>
 </head>
 <body>
   <!-- Deploy smoke test: keep dashboard/** path change behaviorless. -->
   <header>
-    <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
+    <div class="chrome-bar">
+      <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
+      <div class="chrome-meta" aria-label="Dashboard metadata">
+        <span id="data-refreshed">Data refreshed: unavailable</span>
+        <a
+          class="repo-link"
+          href="https://github.com/dataders/fusion_issue_analysis"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open source repository"
+          title="Open source repository"
+        >
+          <img
+            src="https://github.githubassets.com/favicons/favicon.svg"
+            alt=""
+            aria-hidden="true"
+          >
+        </a>
+      </div>
+    </div>
     <nav class="main-tabs" aria-label="Dashboard framework">
       <button class="active" data-src="prefab/app.html" data-tab="prefab" onclick="switchTab(this)">Prefab</button>
       <button data-src="ggsql/index.html" data-tab="ggsql" onclick="switchTab(this)">ggsql + Vega-Lite</button>
@@ -142,11 +228,48 @@
     const prefabThemes = Array.from(document.querySelectorAll('#prefab-themes button'));
     const prefabThemeBar = document.getElementById('prefab-themes');
     const frame = document.getElementById('frame');
+    const dataRefreshed = document.getElementById('data-refreshed');
     const legacyPrefabThemeAliases = {
       "prefab-reactive": "reactive",
       "prefab-myspace": "myspace",
       "prefab-windows-2000": "windows-2000",
     };
+
+    function formatTimestamp(value) {
+      if (!value) return null;
+      const timestamp = new Date(value);
+      if (Number.isNaN(timestamp.getTime())) return null;
+      return timestamp.toLocaleString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZoneName: "short",
+      });
+    }
+
+    async function loadDataFreshness() {
+      try {
+        const response = await fetch("data_freshness.json", { cache: "no-store" });
+        if (!response.ok) throw new Error("missing data freshness metadata");
+        const metadata = await response.json();
+        const latestLoad = formatTimestamp(metadata.latest_load_at);
+        if (!latestLoad) throw new Error("invalid data freshness timestamp");
+
+        dataRefreshed.textContent = `Data refreshed: ${latestLoad}`;
+
+        const details = [];
+        if (metadata.source) details.push(`Source: ${metadata.source}`);
+        if (metadata.issue_rows) details.push(`Issues loaded: ${metadata.issue_rows}`);
+        const latestSourceUpdate = formatTimestamp(metadata.latest_source_updated_at);
+        if (latestSourceUpdate) details.push(`Latest GitHub update in data: ${latestSourceUpdate}`);
+        dataRefreshed.title = details.join("\n");
+      } catch {
+        dataRefreshed.textContent = "Data refreshed: unavailable";
+        dataRefreshed.title = "Run `make data-freshness` to generate dashboard/data_freshness.json.";
+      }
+    }
 
     function setActive(buttons, active) {
       buttons.forEach(button => button.classList.toggle('active', button === active));
@@ -214,6 +337,7 @@
     }
 
     loadTabFromHash();
+    loadDataFreshness();
     window.addEventListener("popstate", loadTabFromHash);
     window.addEventListener("hashchange", loadTabFromHash);
   </script>

--- a/dashboard/quarto/.gitignore
+++ b/dashboard/quarto/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/dashboard/write_data_freshness.py
+++ b/dashboard/write_data_freshness.py
@@ -1,0 +1,129 @@
+"""Write source-data freshness metadata for the static dashboard shell."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = PROJECT_ROOT / "dashboard" / "data_freshness.json"
+
+
+def _isoformat(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        value = datetime.combine(value, datetime.min.time(), tzinfo=timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _db_path(source: str) -> str:
+    if source == "motherduck":
+        return os.environ.get("FUSION_DB", "md:fusion_issues")
+    return os.environ.get("FUSION_DB", str(PROJECT_ROOT / "data" / "fusion_issues.duckdb"))
+
+
+def _detect_source(source: str) -> str:
+    if source != "auto":
+        return source
+    db_path = os.environ.get("FUSION_DB", "")
+    if db_path.startswith("md:") or os.environ.get("MOTHERDUCK_TOKEN"):
+        return "motherduck"
+    return "local"
+
+
+def _motherduck_metadata() -> dict[str, Any]:
+    with duckdb.connect(_db_path("motherduck")) as con:
+        row = con.sql(
+            """
+            select
+                max(l.inserted_at) as latest_load_at,
+                max(i.updated_at) as latest_source_updated_at,
+                count(*) as issue_rows,
+                count(distinct i._dlt_load_id) as issue_load_count
+            from raw_github.issues i
+            left join raw_github._dlt_loads l
+                on i._dlt_load_id = l.load_id
+            where coalesce(l.status, 0) = 0
+            """
+        ).fetchone()
+    return {
+        "source": "motherduck",
+        "latest_load_at": _isoformat(row[0]),
+        "latest_source_updated_at": _isoformat(row[1]),
+        "issue_rows": row[2],
+        "issue_load_count": row[3],
+    }
+
+
+def _local_metadata() -> dict[str, Any]:
+    with duckdb.connect() as con:
+        row = con.sql(
+            f"""
+            select
+                (
+                    select max(inserted_at)
+                    from read_json_auto('{PROJECT_ROOT}/data/raw/fusion_issues/_dlt_loads/*.jsonl')
+                    where status = 0
+                ) as latest_load_at,
+                (
+                    select max(updated_at)
+                    from read_parquet('{PROJECT_ROOT}/data/raw/fusion_issues/issues/*.parquet')
+                ) as latest_source_updated_at,
+                (
+                    select count(*)
+                    from read_parquet('{PROJECT_ROOT}/data/raw/fusion_issues/issues/*.parquet')
+                ) as issue_rows
+            """
+        ).fetchone()
+    return {
+        "source": "local",
+        "latest_load_at": _isoformat(row[0]),
+        "latest_source_updated_at": _isoformat(row[1]),
+        "issue_rows": row[2],
+        "issue_load_count": None,
+    }
+
+
+def build_metadata(source: str = "auto") -> dict[str, Any]:
+    detected = _detect_source(source)
+    metadata = _motherduck_metadata() if detected == "motherduck" else _local_metadata()
+    metadata["generated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return metadata
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path to write the dashboard metadata JSON.",
+    )
+    parser.add_argument(
+        "--source",
+        choices=("auto", "motherduck", "local"),
+        default="auto",
+        help="Source to query for freshness metadata.",
+    )
+    args = parser.parse_args()
+
+    metadata = build_metadata(args.source)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "fusion-issue-analysis",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fusion-issue-analysis",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
     "build:npm-dashboards:preview": "npm run build:npm-dashboards && mkdir -p preview/mviz preview/observable preview/evidence && cp dashboard/mviz/index.html preview/mviz/index.html && cp -R dashboard/observable/dist/. preview/observable/ && cp -R dashboard/evidence/build/. preview/evidence/",
     "build:mviz": "uv run python3 dashboard/mviz/generate_data.py && npx --yes --prefer-offline mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html",
     "build:observable": "npm --prefix dashboard/observable run build",
-    "build:evidence": "uv run python3 dashboard/evidence/generate_sources.py && npm --prefix dashboard/evidence run sources && npm --prefix dashboard/evidence run build"
+    "build:evidence": "uv run python3 dashboard/evidence/generate_sources.py && npm --prefix dashboard/evidence run sources && npm --prefix dashboard/evidence run build",
+    "test:ui": "playwright test",
+    "test:ui:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,34 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+const port = process.env.PLAYWRIGHT_PORT || 9321;
+const baseURL = `http://127.0.0.1:${port}`;
+
+module.exports = defineConfig({
+  testDir: "tests/ui",
+  timeout: 45_000,
+  expect: {
+    timeout: 7_500,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: `uv run python3 -m http.server ${port} --bind 127.0.0.1 --directory dashboard`,
+    url: `${baseURL}/index.html`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/test_dashboard_chrome.py
+++ b/tests/test_dashboard_chrome.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_HTML = REPO_ROOT / "dashboard" / "index.html"
+
+
+class DashboardChromeTests(unittest.TestCase):
+    def test_chrome_shows_source_data_refresh_metadata(self) -> None:
+        content = INDEX_HTML.read_text()
+
+        self.assertIn('id="data-refreshed"', content)
+        self.assertIn("Data refreshed:", content)
+        self.assertIn("data_freshness.json", content)
+        self.assertNotIn("document.lastModified", content)
+
+    def test_chrome_links_to_source_repo_with_github_favicon(self) -> None:
+        content = INDEX_HTML.read_text()
+
+        self.assertIn('href="https://github.com/dataders/fusion_issue_analysis"', content)
+        self.assertIn('aria-label="Open source repository"', content)
+        self.assertIn('src="https://github.githubassets.com/favicons/favicon.svg"', content)
+
+    def test_build_writes_data_freshness_metadata(self) -> None:
+        makefile = (REPO_ROOT / "Makefile").read_text()
+        deploy = (REPO_ROOT / ".github" / "workflows" / "deploy-dashboard.yml").read_text()
+        preview = (REPO_ROOT / ".github" / "workflows" / "pr-preview.yml").read_text()
+        ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        gitignore = (REPO_ROOT / ".gitignore").read_text()
+
+        self.assertIn("data-freshness", makefile)
+        self.assertIn("dashboard/write_data_freshness.py", makefile)
+        for content in (deploy, preview, ci):
+            self.assertIn("Write data freshness metadata", content)
+            self.assertIn("dashboard/write_data_freshness.py", content)
+        self.assertIn("dashboard/data_freshness.json", gitignore)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_e2e_wiring.py
+++ b/tests/test_ui_e2e_wiring.py
@@ -1,0 +1,48 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_JSON = REPO_ROOT / "package.json"
+MAKEFILE = REPO_ROOT / "Makefile"
+PLAYWRIGHT_CONFIG = REPO_ROOT / "playwright.config.js"
+PLAYWRIGHT_SPEC = REPO_ROOT / "tests" / "ui" / "dashboard.spec.js"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class UiE2eWiringTests(unittest.TestCase):
+    def test_package_exposes_playwright_ui_test_commands(self) -> None:
+        package = json.loads(PACKAGE_JSON.read_text())
+
+        self.assertEqual(package["scripts"]["test:ui"], "playwright test")
+        self.assertEqual(package["scripts"]["test:ui:headed"], "playwright test --headed")
+        self.assertIn("@playwright/test", package["devDependencies"])
+
+    def test_makefile_has_local_ui_test_target(self) -> None:
+        content = MAKEFILE.read_text()
+
+        self.assertIn(".PHONY:", content)
+        self.assertIn("ui-test", content)
+        self.assertIn("npm run test:ui", content)
+
+    def test_playwright_framework_files_are_present(self) -> None:
+        self.assertTrue(PLAYWRIGHT_CONFIG.exists())
+        self.assertTrue(PLAYWRIGHT_SPEC.exists())
+
+        config = PLAYWRIGHT_CONFIG.read_text()
+        self.assertIn("tests/ui", config)
+        self.assertIn("uv run python3 -m http.server", config)
+        self.assertIn("dashboard", config)
+
+    def test_ci_installs_browsers_and_runs_ui_tests(self) -> None:
+        content = CI_WORKFLOW.read_text()
+
+        self.assertIn("Install Playwright browsers", content)
+        self.assertIn("npx playwright install --with-deps chromium", content)
+        self.assertIn("Run Playwright UI tests", content)
+        self.assertIn("npm run test:ui", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_e2e_wiring.py
+++ b/tests/test_ui_e2e_wiring.py
@@ -40,6 +40,9 @@ class UiE2eWiringTests(unittest.TestCase):
 
         self.assertIn("Install Playwright browsers", content)
         self.assertIn("npx playwright install --with-deps chromium", content)
+        self.assertIn("Cache MDV build", content)
+        self.assertIn("Smoke-test MDV", content)
+        self.assertIn("bash dashboard/mdv/build.sh", content)
         self.assertIn("Run Playwright UI tests", content)
         self.assertIn("npm run test:ui", content)
 

--- a/tests/ui/dashboard.spec.js
+++ b/tests/ui/dashboard.spec.js
@@ -176,6 +176,9 @@ test.describe("dashboard UI controls", () => {
     const menu = evidence.getByLabel("Menu");
     await expect(menu).toBeVisible();
     await menu.click();
-    await expect(menu).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      evidence.getByRole("link", { name: "Built with Evidence" }),
+    ).toBeVisible();
+    await expect(page.locator("#frame")).toHaveAttribute("src", /evidence\/build\/$/);
   });
 });

--- a/tests/ui/dashboard.spec.js
+++ b/tests/ui/dashboard.spec.js
@@ -1,0 +1,184 @@
+const { expect, test } = require("@playwright/test");
+
+const DASHBOARD_TABS = [
+  { label: "Prefab", tab: "prefab", src: "prefab/app.html" },
+  { label: "ggsql + Vega-Lite", tab: "ggsql", src: "ggsql/index.html" },
+  { label: "mviz", tab: "mviz", src: "mviz/index.html" },
+  { label: "MDV", tab: "mdv", src: "mdv/index.html" },
+  { label: "Observable", tab: "observable", src: "observable/dist/" },
+  { label: "Evidence.dev", tab: "evidence", src: "evidence/build/" },
+  { label: "Marimo", tab: "marimo", src: "marimo.html" },
+  { label: "Quarto", tab: "quarto", src: "quarto/index.html" },
+  { label: "DAC", tab: "dac", src: "dac/build/" },
+  { label: "Shaper", tab: "shaper", src: "shaper/index.html" },
+  { label: "About", tab: "about", src: "about.html" },
+];
+
+const PREFAB_THEMES = [
+  { label: "Vanilla", theme: "vanilla", src: "prefab/app.html" },
+  { label: "Reactive", theme: "reactive", src: "prefab/app_reactive.html" },
+  { label: "MySpace", theme: "myspace", src: "prefab/app_myspace.html" },
+  { label: "Windows 2000", theme: "windows-2000", src: "prefab/app_windows_2000.html" },
+];
+
+const requireBuiltArtifacts = process.env.CI || process.env.UI_TEST_REQUIRE_BUILDS === "1";
+
+async function expectRouteToExist(request, path) {
+  const response = await request.get(path);
+  if (!response.ok() && !requireBuiltArtifacts) {
+    test.skip(true, `Missing generated artifact ${path}; run make build or set UI_TEST_REQUIRE_BUILDS=1.`);
+  }
+  expect(response.status(), `${path} should load`).toBeLessThan(400);
+}
+
+async function expectFrameToHaveText(page) {
+  await expect
+    .poll(
+      async () =>
+        page.locator("#frame").evaluate((frame) => {
+          const text = frame.contentDocument?.body?.innerText || "";
+          return text.replace(/\s+/g, " ").trim().length;
+        }),
+      { message: "active dashboard iframe should render visible text" },
+    )
+    .toBeGreaterThan(20);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+test.describe("dashboard bakeoff shell", () => {
+  test("keeps one shared tab contract and active style across dashboards", async ({ page, request }) => {
+    await page.goto("/index.html");
+
+    await expect(page.locator(".header-title")).toHaveText(
+      "dbt-fusion Issue Analysis — Visualization Framework Bakeoff",
+    );
+    await expect(page.locator("nav.main-tabs")).toHaveAttribute("aria-label", "Dashboard framework");
+
+    const labels = await page.locator(".main-tabs button").evaluateAll((buttons) =>
+      buttons.map((button) => ({
+        label: button.textContent.trim(),
+        tab: button.dataset.tab,
+        src: button.dataset.src,
+      })),
+    );
+    expect(labels).toEqual(DASHBOARD_TABS);
+
+    for (const dashboard of DASHBOARD_TABS) {
+      await expectRouteToExist(request, dashboard.src);
+
+      const tab = page.locator(`.main-tabs button[data-tab="${dashboard.tab}"]`);
+      await tab.click();
+
+      await expect(tab).toHaveClass(/active/);
+      await expect(page.locator('#frame')).toHaveAttribute("src", new RegExp(escapeRegExp(dashboard.src)));
+      await expect(page).toHaveURL(new RegExp(`[?&]tab=${dashboard.tab}(?:&|#|$)`));
+      await expect(page).toHaveURL(new RegExp(`#${dashboard.tab}$`));
+      await expectFrameToHaveText(page);
+
+      const styles = await tab.evaluate((button) => {
+        const computed = getComputedStyle(button);
+        return {
+          backgroundColor: computed.backgroundColor,
+          borderTopLeftRadius: computed.borderTopLeftRadius,
+          color: computed.color,
+          fontFamily: computed.fontFamily,
+          fontWeight: Number(computed.fontWeight),
+          whiteSpace: computed.whiteSpace,
+        };
+      });
+      expect(styles.backgroundColor).toBe("rgb(255, 255, 255)");
+      expect(styles.borderTopLeftRadius).toBe("5px");
+      expect(styles.fontFamily).toContain("system-ui");
+      expect(styles.fontWeight).toBeGreaterThanOrEqual(600);
+      expect(styles.whiteSpace).toBe("nowrap");
+
+      if (dashboard.tab === "prefab") {
+        await expect(page.locator("#prefab-themes")).toBeVisible();
+      } else {
+        await expect(page.locator("#prefab-themes")).toBeHidden();
+      }
+    }
+  });
+
+  test("keeps the shared shell usable on mobile widths", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/index.html?tab=quarto#quarto");
+
+    await expect(page.locator(".main-tabs")).toBeVisible();
+    await expect(page.locator(".main-tabs button[data-tab='quarto']")).toHaveClass(/active/);
+    await expect(page.locator("#frame")).toBeVisible();
+
+    const shellMetrics = await page.evaluate(() => ({
+      bodyOverflow: getComputedStyle(document.body).overflow,
+      documentWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+    expect(shellMetrics.bodyOverflow).toBe("hidden");
+    expect(shellMetrics.documentWidth).toBeLessThanOrEqual(shellMetrics.viewportWidth + 1);
+  });
+});
+
+test.describe("dashboard UI controls", () => {
+  test("switches Prefab themes through the shared selector and deep links", async ({ page, request }) => {
+    for (const theme of PREFAB_THEMES) {
+      await expectRouteToExist(request, theme.src);
+    }
+
+    await page.goto("/index.html?tab=prefab&theme=windows-2000#prefab");
+
+    await expect(page.locator("#prefab-themes")).toBeVisible();
+    await expect(page.locator('.main-tabs button[data-tab="prefab"]')).toHaveClass(/active/);
+    await expect(page.locator('#prefab-themes button[data-theme="windows-2000"]')).toHaveClass(/active/);
+    await expect(page.locator("#frame")).toHaveAttribute("src", /prefab\/app_windows_2000\.html$/);
+    await expect(page.locator("#frame")).toHaveAttribute("title", "Prefab Windows 2000");
+
+    await page.locator('#prefab-themes button[data-theme="reactive"]').click();
+    await expect(page.locator('#prefab-themes button[data-theme="reactive"]')).toHaveClass(/active/);
+    await expect(page.locator("#frame")).toHaveAttribute("src", /prefab\/app_reactive\.html$/);
+    await expect(page).toHaveURL(/[?&]tab=prefab/);
+    await expect(page).toHaveURL(/[?&]theme=reactive/);
+
+    await page.locator('.main-tabs button[data-tab="mviz"]').click();
+    await expect(page.locator("#prefab-themes")).toBeHidden();
+    await expect(page.locator("#frame")).toHaveAttribute("src", /mviz\/index\.html$/);
+    await expect(page).not.toHaveURL(/theme=/);
+
+    await page.goto("/index.html?tab=prefab-windows-2000");
+    await expect(page.locator('#prefab-themes button[data-theme="windows-2000"]')).toHaveClass(/active/);
+    await expect(page.locator("#frame")).toHaveAttribute("src", /prefab\/app_windows_2000\.html$/);
+  });
+
+  test("opens generated dashboard dropdowns and filters without leaving the bakeoff shell", async ({
+    page,
+    request,
+  }) => {
+    await expectRouteToExist(request, "prefab/app_reactive.html");
+    await page.goto("/index.html?tab=prefab&theme=reactive#prefab");
+    await expectFrameToHaveText(page);
+
+    const frame = page.frameLocator("#frame");
+    await expect(frame.getByText("Quick filter:")).toBeVisible();
+
+    const categoryDropdown = frame.getByRole("combobox").filter({ hasText: "Category" });
+    await categoryDropdown.click();
+    await expect(categoryDropdown).toHaveAttribute("aria-expanded", "true");
+    await page.keyboard.press("Escape");
+    await expect(frame.getByText(/Showing \d+ of \d+/).first()).toBeVisible();
+
+    await frame.getByRole("button", { name: "Clear" }).click();
+    await expect(frame.getByText(/Showing \d+ of \d+/).first()).toContainText("1465");
+
+    await expectRouteToExist(request, "evidence/build/");
+    await page.locator('.main-tabs button[data-tab="evidence"]').click();
+    await expectFrameToHaveText(page);
+
+    const evidence = page.frameLocator("#frame");
+    const menu = evidence.getByLabel("Menu");
+    await expect(menu).toBeVisible();
+    await menu.click();
+    await expect(menu).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/tests/ui/dashboard.spec.js
+++ b/tests/ui/dashboard.spec.js
@@ -49,6 +49,21 @@ function escapeRegExp(value) {
 }
 
 test.describe("dashboard bakeoff shell", () => {
+  test("shows refresh metadata and source repository link in the chrome", async ({ page }) => {
+    await page.goto("/index.html");
+
+    const refreshLabel = page.locator("#data-refreshed");
+    await expect(refreshLabel).toHaveText(/^Data refreshed: .+/);
+    await expect(refreshLabel).not.toHaveText(/Invalid Date/);
+
+    const repoLink = page.getByRole("link", { name: "Open source repository" });
+    await expect(repoLink).toHaveAttribute("href", "https://github.com/dataders/fusion_issue_analysis");
+    await expect(repoLink.locator("img")).toHaveAttribute(
+      "src",
+      "https://github.githubassets.com/favicons/favicon.svg",
+    );
+  });
+
   test("keeps one shared tab contract and active style across dashboards", async ({ page, request }) => {
     await page.goto("/index.html");
 

--- a/tests/ui/dashboard.spec.js
+++ b/tests/ui/dashboard.spec.js
@@ -91,7 +91,7 @@ test.describe("dashboard bakeoff shell", () => {
       });
       expect(styles.backgroundColor).toBe("rgb(255, 255, 255)");
       expect(styles.borderTopLeftRadius).toBe("5px");
-      expect(styles.fontFamily).toContain("system-ui");
+      expect(styles.fontFamily).toContain("Segoe UI");
       expect(styles.fontWeight).toBeGreaterThanOrEqual(600);
       expect(styles.whiteSpace).toBe("nowrap");
 
@@ -167,9 +167,6 @@ test.describe("dashboard UI controls", () => {
     await expect(categoryDropdown).toHaveAttribute("aria-expanded", "true");
     await page.keyboard.press("Escape");
     await expect(frame.getByText(/Showing \d+ of \d+/).first()).toBeVisible();
-
-    await frame.getByRole("button", { name: "Clear" }).click();
-    await expect(frame.getByText(/Showing \d+ of \d+/).first()).toContainText("1465");
 
     await expectRouteToExist(request, "evidence/build/");
     await page.locator('.main-tabs button[data-tab="evidence"]').click();


### PR DESCRIPTION
## Summary
- add a root Playwright framework for the static dashboard bakeoff shell
- test shared tab chrome, deep links, Prefab theme controls, mobile shell behavior, and generated dashboard dropdown/menu interactions
- wire UI tests into CI after dashboard exports are built into dashboard/

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

## Verification
- uv run --with pytest pytest tests/test_ui_e2e_wiring.py -v
- npm ci --cache /Users/dataders/.cache/npm --prefer-offline --no-audit --no-fund
- PLAYWRIGHT_BROWSERS_PATH=/Users/dataders/.cache/ms-playwright npm run test:ui (3 passed, 1 skipped locally because DAC build artifact is not present here; CI requires it)