### PR TITLE
Show source data freshness in dashboard chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        if: github.actor != 'dependabot[bot]'
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       # ── Dashboard smoke-test (all frameworks, no || true) ─────────────────
       # Data comes from MotherDuck — extract.yml keeps it fresh 4x/day.
       # No extract or dbt build here; those run in extract.yml on schedule

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -68,6 +68,11 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       - name: Export Prefab dashboards
         id: prefab
         continue-on-error: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Build Shaper tab
         run: uv run python3 dashboard/shaper/build.py
 
+      - name: Write data freshness metadata
+        if: github.actor != 'dependabot[bot]'
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+        run: uv run python dashboard/write_data_freshness.py
+
       # Data comes from MotherDuck — no extract or dbt build needed.
 
       - name: Export Prefab dashboards
@@ -65,6 +71,7 @@ jobs:
           mkdir -p preview/prefab
           cp dashboard/index.html preview/index.html
           cp dashboard/about.html preview/about.html
+          cp dashboard/data_freshness.json preview/data_freshness.json
           mkdir -p preview/shaper
           cp dashboard/shaper/index.html preview/shaper/index.html
           cp dashboard/shaper/fusion-issue-health.dashboard.sql preview/shaper/fusion-issue-health.dashboard.sql

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ dashboard/observable/node_modules/
 
 # Dashboard build artifacts (index.html is the bakeoff wrapper, tracked in git)
 dashboard/about.html
+dashboard/data_freshness.json
 dashboard/app.html
 dashboard/app_myspace.html
 dashboard/prefab/app.html

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PORT ?= 8081
 
 .DEFAULT_GOAL := help
-.PHONY: serve build about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
+.PHONY: serve build data-freshness about dbt extract prefab ggsql mviz npm-dashboards mdv marimo observable evidence quarto dac shaper kill-server clean help
 
 # ── Top-level ────────────────────────────────────────────────────────────────
 
@@ -12,7 +12,11 @@ serve: build kill-server
 	@sleep 1 && open http://localhost:$(PORT)
 
 ## build        Build every dashboard's static output (no serve)
-build: about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
+build: data-freshness about prefab ggsql npm-dashboards mdv marimo quarto dac shaper
+
+## data-freshness Write source-data freshness metadata for the dashboard chrome
+data-freshness:
+	uv run python dashboard/write_data_freshness.py
 
 ## about        Render dashboard/about.html from dashboard/about.md
 about:
@@ -87,6 +91,7 @@ kill-server:
 ## clean        Remove all generated dashboard files
 clean:
 	rm -f  dashboard/prefab/app.html dashboard/prefab/app_reactive.html dashboard/prefab/app_myspace.html dashboard/prefab/app_windows_2000.html
+	rm -f  dashboard/data_freshness.json
 	rm -f  dashboard/ggsql/index.html dashboard/mviz/index.html dashboard/mdv/index.html dashboard/marimo.html
 	rm -rf dashboard/mviz/data dashboard/mdv/data dashboard/observable/dist dashboard/evidence/build
 	rm -f  dashboard/quarto/index.html

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -23,13 +23,59 @@
       border-bottom: 1px solid #333;
     }
 
+    .chrome-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 10px;
+      min-width: 0;
+    }
+
     .header-title {
       font-size: 0.78rem;
       font-weight: 400;
       color: #666;
       letter-spacing: 0.04em;
       text-transform: uppercase;
-      margin-bottom: 10px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chrome-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex: 0 0 auto;
+      color: #777;
+      font-size: 0.76rem;
+      white-space: nowrap;
+    }
+
+    .repo-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border: 1px solid #2d2d2d;
+      border-radius: 4px;
+      background: #1a1a1a;
+      opacity: 0.76;
+      transition: opacity 0.1s, border-color 0.1s;
+    }
+
+    .repo-link:hover,
+    .repo-link:focus-visible {
+      border-color: #666;
+      opacity: 1;
+    }
+
+    .repo-link img {
+      width: 16px;
+      height: 16px;
     }
 
     nav {
@@ -109,12 +155,52 @@
       border: none;
       background: #fff;
     }
+
+    @media (max-width: 720px) {
+      header {
+        padding-right: 12px;
+        padding-left: 12px;
+      }
+
+      .chrome-bar {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .header-title {
+        white-space: normal;
+      }
+
+      .chrome-meta {
+        font-size: 0.72rem;
+      }
+    }
   </style>
 </head>
 <body>
   <!-- Deploy smoke test: keep dashboard/** path change behaviorless. -->
   <header>
-    <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
+    <div class="chrome-bar">
+      <p class="header-title">dbt-fusion Issue Analysis — Visualization Framework Bakeoff</p>
+      <div class="chrome-meta" aria-label="Dashboard metadata">
+        <span id="data-refreshed">Data refreshed: unavailable</span>
+        <a
+          class="repo-link"
+          href="https://github.com/dataders/fusion_issue_analysis"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open source repository"
+          title="Open source repository"
+        >
+          <img
+            src="https://github.githubassets.com/favicons/favicon.svg"
+            alt=""
+            aria-hidden="true"
+          >
+        </a>
+      </div>
+    </div>
     <nav class="main-tabs" aria-label="Dashboard framework">
       <button class="active" data-src="prefab/app.html" data-tab="prefab" onclick="switchTab(this)">Prefab</button>
       <button data-src="ggsql/index.html" data-tab="ggsql" onclick="switchTab(this)">ggsql + Vega-Lite</button>
@@ -142,11 +228,45 @@
     const prefabThemes = Array.from(document.querySelectorAll('#prefab-themes button'));
     const prefabThemeBar = document.getElementById('prefab-themes');
     const frame = document.getElementById('frame');
+    const dataRefreshed = document.getElementById('data-refreshed');
     const legacyPrefabThemeAliases = {
       "prefab-reactive": "reactive",
       "prefab-myspace": "myspace",
       "prefab-windows-2000": "windows-2000",
     };
+
+    function formatTimestamp(value) {
+      if (!value) return null;
+      const timestamp = new Date(value);
+      if (Number.isNaN(timestamp.getTime())) return null;
+      return timestamp.toLocaleString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZoneName: "short",
+      });
+    }
+
+    async function loadDataFreshness() {
+      try {
+        const response = await fetch("data_freshness.json", { cache: "no-store" });
+        if (!response.ok) throw new Error("missing data freshness metadata");
+        const metadata = await response.json();
+        const latestLoad = formatTimestamp(metadata.latest_load_at);
+        if (!latestLoad) throw new Error("invalid data freshness timestamp");
+
+        dataRefreshed.textContent = `Data refreshed: ${latestLoad}`;
+
+        const details = [];
+        if (metadata.source) details.push(`Source: ${metadata.source}`);
+        dataRefreshed.title = details.join("\n");
+      } catch {
+        dataRefreshed.textContent = "Data refreshed: unavailable";
+        dataRefreshed.title = "Run `make data-freshness` to generate dashboard/data_freshness.json.";
+      }
+    }
 
     function setActive(buttons, active) {
       buttons.forEach(button => button.classList.toggle('active', button === active));
@@ -214,6 +334,7 @@
     }
 
     loadTabFromHash();
+    loadDataFreshness();
     window.addEventListener("popstate", loadTabFromHash);
     window.addEventListener("hashchange", loadTabFromHash);
   </script>

--- a/dashboard/write_data_freshness.py
+++ b/dashboard/write_data_freshness.py
@@ -1,0 +1,57 @@
+"""Write dashboard freshness from dlt's built-in load history table."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+OUTPUT = Path(__file__).with_name("data_freshness.json")
+
+
+def _isoformat(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        value = datetime.combine(value, datetime.min.time(), tzinfo=timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _latest_dlt_load_at() -> str | None:
+    if not os.environ.get("MOTHERDUCK_TOKEN"):
+        return None
+
+    db_path = os.environ.get("FUSION_DB", "md:fusion_issues")
+    with duckdb.connect(db_path) as con:
+        latest_load_at = con.sql(
+            """
+            select max(inserted_at)
+            from raw_github._dlt_loads
+            where status = 0
+            """
+        ).fetchone()[0]
+    return _isoformat(latest_load_at)
+
+
+def main() -> None:
+    latest_load_at = _latest_dlt_load_at()
+    metadata = {
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "latest_load_at": latest_load_at,
+        "source": "raw_github._dlt_loads" if latest_load_at else "unavailable",
+    }
+    OUTPUT.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dashboard_chrome.py
+++ b/tests/test_dashboard_chrome.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_HTML = REPO_ROOT / "dashboard" / "index.html"
+
+
+class DashboardChromeTests(unittest.TestCase):
+    def test_chrome_shows_source_data_refresh_metadata(self) -> None:
+        content = INDEX_HTML.read_text()
+
+        self.assertIn('id="data-refreshed"', content)
+        self.assertIn("Data refreshed:", content)
+        self.assertIn("data_freshness.json", content)
+        self.assertNotIn("document.lastModified", content)
+
+    def test_chrome_links_to_source_repo_with_github_favicon(self) -> None:
+        content = INDEX_HTML.read_text()
+
+        self.assertIn('href="https://github.com/dataders/fusion_issue_analysis"', content)
+        self.assertIn('aria-label="Open source repository"', content)
+        self.assertIn('src="https://github.githubassets.com/favicons/favicon.svg"', content)
+
+    def test_build_writes_data_freshness_metadata(self) -> None:
+        makefile = (REPO_ROOT / "Makefile").read_text()
+        deploy = (REPO_ROOT / ".github" / "workflows" / "deploy-dashboard.yml").read_text()
+        preview = (REPO_ROOT / ".github" / "workflows" / "pr-preview.yml").read_text()
+        ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        gitignore = (REPO_ROOT / ".gitignore").read_text()
+
+        self.assertIn("data-freshness", makefile)
+        self.assertIn("dashboard/write_data_freshness.py", makefile)
+        self.assertIn("raw_github._dlt_loads", (REPO_ROOT / "dashboard" / "write_data_freshness.py").read_text())
+        for content in (deploy, preview, ci):
+            self.assertIn("Write data freshness metadata", content)
+            self.assertIn("dashboard/write_data_freshness.py", content)
+        self.assertIn("dashboard/data_freshness.json", gitignore)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Uses dlt’s built-in `raw_github._dlt_loads` table as the source of dashboard data freshness.
- Shows `Data refreshed` plus a GitHub favicon repo link in the dashboard chrome.
- Wires CI, PR preview, deploy, and `make build` to produce `dashboard/data_freshness.json`.

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)

## Tests

- `make data-freshness`
- `uv run python -m unittest tests.test_dashboard_chrome`
- `git diff --check`
