### PR TITLE
fix: recognize fidget-repro-complete as a triage signal

### DIFF
--- a/transform/models/dashboard/issue_triage_health.sql
+++ b/transform/models/dashboard/issue_triage_health.sql
@@ -8,7 +8,7 @@ with issue_triage as (
         i.updated_at,
         max(case when l.label_name = 'triage' then 1 else 0 end) as has_triage,
         max(case when l.label_name = 'needs-repro' then 1 else 0 end) as has_needs_repro,
-        max(case when l.label_name in ('has-repro', 'repro/verified') then 1 else 0 end) as has_repro_verified,
+        max(case when l.label_name in ('has-repro', 'repro/verified', 'fidget-repro-complete') then 1 else 0 end) as has_repro_verified,
         max(case when l.label_name = 'hard-blocker' then 1 else 0 end) as has_hard_blocker,
         max(case when l.label_name = 'release/awaiting-release' then 1 else 0 end) as has_awaiting_release,
         max(case when l.label_name = 'cleanup/stale' then 1 else 0 end) as has_stale_label

--- a/transform/models/dashboard/oldest_untriaged.sql
+++ b/transform/models/dashboard/oldest_untriaged.sql
@@ -5,7 +5,7 @@ with issue_labels_agg as (
     select
         issue_dlt_id,
         max(case when label_name in (
-            'triage', 'needs-repro', 'has-repro', 'repro/verified',
+            'triage', 'needs-repro', 'has-repro', 'repro/verified', 'fidget-repro-complete',
             'hard-blocker', 'release/awaiting-release', 'cleanup/stale'
         ) then 1 else 0 end) as has_triage_signal
     from {{ ref('stg_issue_labels') }}


### PR DESCRIPTION
## Summary

- `fidget-repro-complete` is a Fidget bot label equivalent to `has-repro` / `repro/verified`, but was missing from both triage models
- Bugs with only this label were counted as `no_signal` → showing up in **Slipped through (bugs)** and **Oldest untriaged bugs** (e.g. issue #1640)
- Added `fidget-repro-complete` to the `has_repro_verified` check in `issue_triage_health.sql` and the `has_triage_signal` label set in `oldest_untriaged.sql`

## Test plan

- [x] `dbtf build --select issue_triage_health oldest_untriaged` — both models build and all 11 tests pass
- [ ] Verify issue #1640 no longer appears in the oldest untriaged list after next extract + prod deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)