### PR TITLE
fix: drop pending packages before extract to clear stuck merge jobs

### DIFF
--- a/extract/run.py
+++ b/extract/run.py
@@ -63,11 +63,12 @@ def main():
         max_items=args.limit,
     ).with_resources("issues", "pull_requests")
 
-    # dlt's merge disposition generates a SQL file that fails against a fresh
-    # MotherDuck destination because it assumes child tables already exist.
-    # Replace is safe here — PR data is small and fully replaced each run.
+    # pull_requests uses replace so child tables never need _dlt_root_id.
+    # Drop stuck pending packages so retried merge jobs from prior failed runs
+    # don't resurface (the root cause of the MergeDispositionException).
     if args.motherduck:
         source.resources["pull_requests"].apply_hints(write_disposition="replace")
+        pipeline.drop_pending_packages()
 
     loader_kwargs = {}
     if not args.motherduck:


### PR DESCRIPTION
## Summary

- Failing extract run left a dlt pending package with merge jobs for `pull_requests__comments__reactions`
- That table has no `_dlt_root_id` (was created under replace disposition), so every subsequent scheduled run retried the same failing merge job
- Fix: call `pipeline.drop_pending_packages()` before `pipeline.run()` in MotherDuck mode so stuck packages from prior failures are cleared

## Root cause

`pull_requests__comments__reactions` is a deeply-nested child table that dlt cannot auto-generate `_dlt_root_id` for when the destination tables were first created under `replace` disposition. A previous run crashed mid-load, leaving a pending package whose merge jobs reference that missing column. dlt retried these jobs on every subsequent run.

## Test plan

- [ ] CI build-and-test passes (smoke test hits parquet path, unaffected)
- [ ] Next scheduled extract run completes without `MergeDispositionException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)