### PR TITLE
Fix Evidence and DAC live dashboard builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           DAC_ENVIRONMENT: prod
           DAC_OUTPUT: dashboard/dac/build
         run: |
-          uv run python3 dashboard/dac/render.py
+          uv run python dashboard/dac/render.py
           ! grep -q 'bruin query failed' dashboard/dac/build/index.html
 
       - name: Smoke-test MCP App

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -137,7 +137,7 @@ jobs:
           DAC_ENVIRONMENT: prod
           DAC_OUTPUT: dashboard/dac/build
         run: |
-          uv run python3 dashboard/dac/render.py
+          uv run python dashboard/dac/render.py
           ! grep -q 'bruin query failed' dashboard/dac/build/index.html
 
       - name: Inject MotherDuck read-scaling token

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -148,7 +148,7 @@ jobs:
           DAC_ENVIRONMENT: prod
           DAC_OUTPUT: preview/dac
         run: |
-          uv run python3 dashboard/dac/render.py
+          uv run python dashboard/dac/render.py
           ! grep -q 'bruin query failed' preview/dac/index.html
 
       - name: Upload preview artifact

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ quarto:
 
 ## dac          Build DAC dashboard to static HTML
 dac:
-	uv run python3 dashboard/dac/render.py
+	uv run python dashboard/dac/render.py
 	! grep -q 'bruin query failed' dashboard/dac/build/index.html
 
 ## shaper       Build Shaper source-preview tab

--- a/dashboard/dac/dashboards/fusion-issues.yml
+++ b/dashboard/dac/dashboards/fusion-issues.yml
@@ -8,7 +8,6 @@ rows:
         type: metric
         col: 2
         sql: |
-          set file_search_path='transform';
           select open_issues as value from summary_kpis
         column: value
         format: number
@@ -16,7 +15,6 @@ rows:
         type: metric
         col: 2
         sql: |
-          set file_search_path='transform';
           select closed_4w - opened_4w as value from summary_kpis
         column: value
         format: number
@@ -24,7 +22,6 @@ rows:
         type: metric
         col: 2
         sql: |
-          set file_search_path='transform';
           select rolling_median_close_days as value from summary_kpis
         column: value
         format: number
@@ -32,7 +29,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select pct_responded_48h / 100.0 as value from summary_kpis
         column: value
         format: percentage
@@ -40,7 +36,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select stale_count as value from summary_kpis
         column: value
         format: number
@@ -51,7 +46,6 @@ rows:
         chart: line
         col: 12
         sql: |
-          set file_search_path='transform';
           select week, cumulative_opened, cumulative_closed
           from cumulative_flow
           order by week
@@ -64,7 +58,6 @@ rows:
         chart: line
         col: 6
         sql: |
-          set file_search_path='transform';
           select
             week,
             max(case when issue_category = 'bug' then median_days end) as bugs,
@@ -79,7 +72,6 @@ rows:
         chart: line
         col: 6
         sql: |
-          set file_search_path='transform';
           select week, p25, p50, p75
           from response_pctiles
           order by week
@@ -93,7 +85,6 @@ rows:
         stacked: true
         col: 6
         sql: |
-          set file_search_path='transform';
           select
             age_bucket,
             sum(case when issue_category = 'bug' then issue_count else 0 end) as bug,
@@ -115,7 +106,6 @@ rows:
         chart: bar
         col: 6
         sql: |
-          set file_search_path='transform';
           select label_name, median_days_to_close
           from close_by_label
           order by median_days_to_close desc
@@ -127,7 +117,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select slipped_through_count as value from issue_triage_health
         column: value
         format: number
@@ -135,7 +124,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select triage_queue_count as value from issue_triage_health
         column: value
         format: number
@@ -143,7 +131,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select hard_blocker_count as value from issue_triage_health
         column: value
         format: number
@@ -151,7 +138,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select needs_repro_count as value from issue_triage_health
         column: value
         format: number
@@ -161,7 +147,6 @@ rows:
         type: metric
         col: 4
         sql: |
-          set file_search_path='transform';
           select repro_verified_count as value from issue_triage_health
         column: value
         format: number
@@ -169,7 +154,6 @@ rows:
         type: metric
         col: 4
         sql: |
-          set file_search_path='transform';
           select stale_count as value from issue_triage_health
         column: value
         format: number
@@ -177,7 +161,6 @@ rows:
         type: metric
         col: 4
         sql: |
-          set file_search_path='transform';
           select total_open as value from issue_triage_health
         column: value
         format: number
@@ -187,7 +170,6 @@ rows:
         type: table
         col: 12
         sql: |
-          set file_search_path='transform';
           select issue_number, title, age_days, issue_url
           from oldest_untriaged
           order by age_days desc
@@ -209,7 +191,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select pct_labeled / 100.0 as value from triage_health
         column: value
         format: percentage
@@ -217,7 +198,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select pct_typed / 100.0 as value from triage_health
         column: value
         format: percentage
@@ -225,7 +205,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select pct_assigned / 100.0 as value from triage_health
         column: value
         format: percentage
@@ -233,7 +212,6 @@ rows:
         type: metric
         col: 3
         sql: |
-          set file_search_path='transform';
           select pct_milestoned / 100.0 as value from triage_health
         column: value
         format: percentage
@@ -245,7 +223,6 @@ rows:
         stacked: true
         col: 6
         sql: |
-          set file_search_path='transform';
           select assignee_login, bugs, enhancements
           from assignee_workload
           order by open_issues desc
@@ -255,7 +232,6 @@ rows:
         type: table
         col: 6
         sql: |
-          set file_search_path='transform';
           select issue_number, title, issue_category, reactions_total_count, age_days
           from community_priorities
           order by reactions_total_count desc

--- a/dashboard/dac/render.py
+++ b/dashboard/dac/render.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -11,7 +12,6 @@ ROOT = Path(__file__).resolve().parents[2]
 DAC_DIR = ROOT / "dashboard" / "dac"
 SOURCE_DASHBOARDS = DAC_DIR / "dashboards"
 CONFIG = DAC_DIR / "bruin.yml"
-PLACEHOLDER = "set file_search_path='transform';"
 DASHBOARD_NAME = "Fusion Issue Analysis"
 ERROR_MARKERS = (
     "bruin query failed",
@@ -20,11 +20,8 @@ ERROR_MARKERS = (
 )
 
 
-def render_dashboard_sources(destination: Path, transform_dir: str) -> None:
+def render_dashboard_sources(destination: Path) -> None:
     shutil.copytree(SOURCE_DASHBOARDS, destination)
-    dashboard = destination / "fusion-issues.yml"
-    content = dashboard.read_text()
-    dashboard.write_text(content.replace(PLACEHOLDER, f"set file_search_path='{transform_dir}';"))
 
 
 def warm_bruin_query_runtime(config: Path, env: dict[str, str], env_name: str) -> None:
@@ -42,7 +39,28 @@ def warm_bruin_query_runtime(config: Path, env: dict[str, str], env_name: str) -
         "--output",
         "json",
     ]
-    subprocess.run(command, check=True, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    subprocess.run(
+        command,
+        check=True,
+        env=env,
+        cwd=ROOT / "transform",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def extract_static_payload(content: str) -> dict:
+    marker = "window.__DAC_STATIC__="
+    start = content.find(marker)
+    if start == -1:
+        raise SystemExit("DAC static build is missing window.__DAC_STATIC__")
+
+    start += len(marker)
+    end = content.find(";</script>", start)
+    if end == -1:
+        raise SystemExit("DAC static build payload is not terminated")
+
+    return json.loads(content[start:end])
 
 
 def validate_static_output(path: Path) -> None:
@@ -51,22 +69,48 @@ def validate_static_output(path: Path) -> None:
     if matches:
         raise SystemExit(f"DAC static build contains query errors: {', '.join(matches)}")
 
+    payload = extract_static_payload(content)
+    widget_data = payload.get("widgetData") or {}
+    if not widget_data:
+        raise SystemExit("DAC static build does not contain widget data")
+
+    invalid = []
+    for widget_id, result in widget_data.items():
+        if result.get("error"):
+            invalid.append(f"{widget_id}: {result['error']}")
+        elif not result.get("columns"):
+            invalid.append(f"{widget_id}: missing columns")
+        elif result.get("rows") is None:
+            invalid.append(f"{widget_id}: missing rows")
+
+    if invalid:
+        raise SystemExit("DAC static build contains invalid widget data: " + "; ".join(invalid[:5]))
+
+
+def resolve_output_path(raw_output: str | Path) -> Path:
+    output = Path(raw_output)
+    if output.is_absolute():
+        return output
+    return ROOT / output
+
 
 def main() -> None:
-    output = Path(os.environ.get("DAC_OUTPUT", DAC_DIR / "build"))
-    transform_dir = os.environ.get("FUSION_TRANSFORM_DIR", str(ROOT / "transform"))
+    output = resolve_output_path(os.environ.get("DAC_OUTPUT", DAC_DIR / "build"))
     env = os.environ.copy()
-    env.setdefault("FUSION_DB", "../../data/fusion_issues.duckdb")
+    env.setdefault("FUSION_DB", str(ROOT / "data" / "fusion_issues.duckdb"))
     env_name = env.get("DAC_ENVIRONMENT")
 
     with tempfile.TemporaryDirectory(prefix="fusion-dac-") as tmp:
         tmp_path = Path(tmp)
         dashboards = tmp_path / "dashboards"
-        render_dashboard_sources(dashboards, transform_dir)
-        config = CONFIG
+        render_dashboard_sources(dashboards)
+        config = tmp_path / "bruin.yml"
+        config_text = CONFIG.read_text()
         if env_name:
-            config = tmp_path / "bruin.yml"
-            config.write_text(CONFIG.read_text().replace("default_environment: local", f"default_environment: {env_name}"))
+            config_text = config_text.replace("default_environment: local", f"default_environment: {env_name}")
+        config.write_text(config_text)
+
+        if env_name:
             warm_bruin_query_runtime(config, env, env_name)
 
         command = ["dac", "--config", str(config)]
@@ -79,7 +123,7 @@ def main() -> None:
             "--output",
             str(output),
         ])
-        subprocess.run(command, check=True, env=env)
+        subprocess.run(command, check=True, env=env, cwd=ROOT / "transform")
 
     fix_asset_paths(output / "index.html")
     validate_static_output(output / "index.html")

--- a/dashboard/evidence/validate_build.py
+++ b/dashboard/evidence/validate_build.py
@@ -1,0 +1,56 @@
+"""Validate that Evidence's static build can be served from /evidence/build."""
+
+import json
+from pathlib import Path
+
+
+BUILD_DIR = Path(__file__).resolve().parent / "build"
+
+
+def normalize_manifest_paths(manifest: dict) -> bool:
+    changed = False
+    rendered_files = manifest.get("renderedFiles", {})
+
+    for source, paths in rendered_files.items():
+        normalized_paths = []
+        for rel_path in paths:
+            if rel_path.startswith("static/data/"):
+                rel_path = "data/" + rel_path.removeprefix("static/data/")
+                changed = True
+            normalized_paths.append(rel_path)
+        rendered_files[source] = normalized_paths
+
+    return changed
+
+
+def validate_build(build_dir: Path = BUILD_DIR) -> None:
+    manifest_path = build_dir / "data" / "manifest.json"
+    if not manifest_path.exists():
+        raise SystemExit(f"Evidence build manifest missing: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    if normalize_manifest_paths(manifest):
+        manifest_path.write_text(json.dumps(manifest))
+
+    missing: list[str] = []
+    invalid: list[str] = []
+    rendered_files = manifest.get("renderedFiles", {})
+
+    for paths in rendered_files.values():
+        for rel_path in paths:
+            if rel_path.startswith("/") or rel_path.startswith("static/"):
+                invalid.append(rel_path)
+            if not (build_dir / rel_path).exists():
+                missing.append(rel_path)
+
+    if invalid or missing:
+        details = []
+        if invalid:
+            details.append("invalid data URL paths: " + ", ".join(invalid[:5]))
+        if missing:
+            details.append("missing data files: " + ", ".join(missing[:5]))
+        raise SystemExit("Evidence static build is not portable: " + "; ".join(details))
+
+
+if __name__ == "__main__":
+    validate_build()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:npm-dashboards:preview": "npm run build:npm-dashboards && mkdir -p preview/mviz preview/observable preview/evidence && cp dashboard/mviz/index.html preview/mviz/index.html && cp -R dashboard/observable/dist/. preview/observable/ && cp -R dashboard/evidence/build/. preview/evidence/",
     "build:mviz": "uv run python3 dashboard/mviz/generate_data.py && npx --yes --prefer-offline mviz@1.6.7 dashboard/mviz/dashboard.md -o dashboard/mviz/index.html",
     "build:observable": "npm --prefix dashboard/observable run build",
-    "build:evidence": "uv run python3 dashboard/evidence/generate_sources.py && npm --prefix dashboard/evidence run sources && npm --prefix dashboard/evidence run build",
+    "build:evidence": "uv run python dashboard/evidence/generate_sources.py && npm --prefix dashboard/evidence run sources && npm --prefix dashboard/evidence run build && uv run python dashboard/evidence/validate_build.py",
     "test:ui": "playwright test",
     "test:ui:headed": "playwright test --headed"
   },

--- a/tests/test_dac_dashboard.py
+++ b/tests/test_dac_dashboard.py
@@ -25,8 +25,8 @@ class DacDashboardTests(unittest.TestCase):
 
     def test_makefile_builds_and_cleans_dac(self) -> None:
         content = MAKEFILE.read_text()
-        self.assertIn("build: about prefab ggsql mviz mdv marimo observable evidence quarto dac", content)
-        self.assertIn("uv run python3 dashboard/dac/render.py", content)
+        self.assertIn("build: data-freshness about prefab ggsql npm-dashboards mdv marimo quarto dac shaper", content)
+        self.assertIn("uv run python dashboard/dac/render.py", content)
         self.assertIn("dashboard/dac/build", content)
 
     def test_ci_and_preview_workflows_build_dac(self) -> None:
@@ -37,10 +37,10 @@ class DacDashboardTests(unittest.TestCase):
         for content in (preview, ci, deploy):
             self.assertIn("Install DAC", content)
             self.assertIn("DAC_ENVIRONMENT: prod", content)
-            self.assertIn("uv run python3 dashboard/dac/render.py", content)
+            self.assertIn("uv run python dashboard/dac/render.py", content)
 
         self.assertIn("preview/dac", preview)
-        self.assertIn("| DAC | `dac/index.html` |", preview)
+        self.assertIn("DAC | \\`dac/index.html\\`", preview)
         self.assertIn("dashboard/dac/build", deploy)
 
     def test_dac_project_uses_fusion_issue_marts(self) -> None:
@@ -51,15 +51,16 @@ class DacDashboardTests(unittest.TestCase):
         self.assertIn("motherduck:", config)
         self.assertIn("token: ${MOTHERDUCK_TOKEN}", config)
         self.assertIn("database: fusion_issues", config)
-        self.assertIn('env.setdefault("FUSION_DB", "../../data/fusion_issues.duckdb")', DAC_RENDER.read_text())
+        render = DAC_RENDER.read_text()
+        self.assertIn('env.setdefault("FUSION_DB", str(ROOT / "data" / "fusion_issues.duckdb"))', render)
         self.assertIn("name: Fusion Issue Analysis", dashboard)
         self.assertIn("connection: fusion", dashboard)
-        self.assertIn("from fct_issues", dashboard)
+        self.assertIn("from summary_kpis", dashboard)
         self.assertIn("cumulative_flow", dashboard)
         self.assertIn("open_issues", dashboard)
-        self.assertIn("FUSION_TRANSFORM_DIR", DAC_RENDER.read_text())
-        self.assertIn("default_environment: {env_name}", DAC_RENDER.read_text())
-        self.assertIn("warm_bruin_query_runtime(config, env, env_name)", DAC_RENDER.read_text())
+        self.assertNotIn("set file_search_path", dashboard)
+        self.assertIn("default_environment: {env_name}", render)
+        self.assertIn("warm_bruin_query_runtime(config, env, env_name)", render)
 
     def test_dac_asset_rewrite_makes_nested_static_build_portable(self) -> None:
         spec = importlib.util.spec_from_file_location("fix_asset_paths", DAC_ASSET_FIX)
@@ -92,6 +93,29 @@ class DacDashboardTests(unittest.TestCase):
 
             with self.assertRaises(SystemExit):
                 module.validate_static_output(path)
+
+    def test_dac_static_output_validation_rejects_empty_widget_results(self) -> None:
+        spec = importlib.util.spec_from_file_location("render", DAC_RENDER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "index.html"
+            path.write_text('<script>window.__DAC_STATIC__={"widgetData":{"Open Issues":{"columns":null,"rows":[]}}};</script>')
+
+            with self.assertRaises(SystemExit):
+                module.validate_static_output(path)
+
+    def test_dac_render_resolves_relative_outputs_from_repo_root(self) -> None:
+        spec = importlib.util.spec_from_file_location("render", DAC_RENDER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        self.assertEqual(module.resolve_output_path("dashboard/dac/build"), REPO_ROOT / "dashboard" / "dac" / "build")
 
 
 if __name__ == "__main__":

--- a/tests/test_evidence_dashboard.py
+++ b/tests/test_evidence_dashboard.py
@@ -1,0 +1,76 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_JSON = REPO_ROOT / "package.json"
+EVIDENCE_VALIDATE = REPO_ROOT / "dashboard" / "evidence" / "validate_build.py"
+
+
+class EvidenceDashboardTests(unittest.TestCase):
+    def test_evidence_build_validates_manifest_after_static_export(self) -> None:
+        script = PACKAGE_JSON.read_text()
+
+        self.assertIn("npm --prefix dashboard/evidence run sources", script)
+        self.assertIn("npm --prefix dashboard/evidence run build", script)
+        self.assertNotIn("EVIDENCE_DATA_URL_PREFIX=data", script)
+        self.assertIn("uv run python dashboard/evidence/validate_build.py", script)
+
+    def test_evidence_validation_rejects_manifest_paths_that_do_not_exist(self) -> None:
+        spec = importlib.util.spec_from_file_location("validate_build", EVIDENCE_VALIDATE)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            build = Path(tmpdir)
+            manifest = build / "data" / "manifest.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text('{"renderedFiles": {"fusion.summary": ["static/data/fusion/summary.parquet"]}}')
+
+            with self.assertRaises(SystemExit):
+                module.validate_build(build)
+
+    def test_evidence_validation_rewrites_static_manifest_paths_to_deployed_data_paths(self) -> None:
+        spec = importlib.util.spec_from_file_location("validate_build", EVIDENCE_VALIDATE)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            build = Path(tmpdir)
+            data_file = build / "data" / "fusion" / "summary.parquet"
+            data_file.parent.mkdir(parents=True)
+            data_file.write_bytes(b"PAR1")
+            manifest = build / "data" / "manifest.json"
+            manifest.write_text('{"renderedFiles": {"fusion.summary": ["static/data/fusion/summary.parquet"]}}')
+
+            module.validate_build(build)
+
+            self.assertIn("data/fusion/summary.parquet", manifest.read_text())
+            self.assertNotIn("static/data/fusion/summary.parquet", manifest.read_text())
+
+    def test_evidence_validation_accepts_manifest_paths_inside_build_dir(self) -> None:
+        spec = importlib.util.spec_from_file_location("validate_build", EVIDENCE_VALIDATE)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            build = Path(tmpdir)
+            data_file = build / "data" / "fusion" / "summary.parquet"
+            data_file.parent.mkdir(parents=True)
+            data_file.write_bytes(b"PAR1")
+            manifest = build / "data" / "manifest.json"
+            manifest.write_text('{"renderedFiles": {"fusion.summary": ["data/fusion/summary.parquet"]}}')
+
+            module.validate_build(build)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rewrite Evidence build manifests so deployed parquet paths resolve under /evidence/build/data
- remove DAC per-query file_search_path SET statements that caused Bruin to bake empty SET results
- validate DAC static widget payloads and Evidence data paths during build

## Verification
- uv run python -m unittest tests/test_evidence_dashboard.py tests/test_dac_dashboard.py
- zsh -lc 'source /Users/dataders/Developer/dotfiles_env/secrets.zsh; EVIDENCE_BASE_PATH=/evidence/build npm run build:evidence'
- zsh -lc 'source /Users/dataders/Developer/dotfiles_env/secrets.zsh; PATH=/private/tmp/fusion-dac-bin:/Users/dataders/.local/bin:/Users/dataders/.codeium/windsurf/bin:/Users/dataders/.wasmtime/bin:/opt/homebrew/opt/openjdk@17/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/quarto/bin:/Users/dataders/.codex/tmp/arg0/codex-arg0UAEYbV:/Users/dataders/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS:/usr/local/sbin:/opt/homebrew/opt/fzf/bin DAC_ENVIRONMENT=prod DAC_OUTPUT=dashboard/dac/build uv run python dashboard/dac/render.py'
- local static checks returned 200 for /evidence/build/, a manifest parquet path, and /dac/build/; DAC payload had 24 widgets with populated rows/columns

## Dashboard Preview
🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)