### PR TITLE
fix: pin duckdb to 1.5.2 for MotherDuck compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "dbt-duckdb>=1.10.1",
     "dlt[filesystem,parquet]>=1.24.0",
-    "duckdb>=1.5.2",
+    "duckdb==1.5.2",
     "marimo>=0.23.2",
     "markdown>=3.10.2",
     "numpy>=2.4.4",

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-06T01:08:54.448817Z"
+exclude-newer = "2026-05-14T03:36:33.899254Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1155,7 +1155,7 @@ dev = [
 requires-dist = [
     { name = "dbt-duckdb", specifier = ">=1.10.1" },
     { name = "dlt", extras = ["filesystem", "parquet"], specifier = ">=1.24.0" },
-    { name = "duckdb", specifier = ">=1.5.2" },
+    { name = "duckdb", specifier = "==1.5.2" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "marimo", specifier = ">=0.23.2" },
     { name = "markdown", specifier = ">=3.10.2" },


### PR DESCRIPTION
## Summary

- Pins `duckdb==1.5.2` in `pyproject.toml` (was `>=1.5.2`)
- Regenerates `uv.lock` to lock the resolved version

## Why

MotherDuck does not yet support duckdb 1.5.3. Without the pin, `uv` can resolve 1.5.3 and break the ETL pipeline against the MotherDuck destination.

## Test plan

- [x] `uv sync` resolves cleanly with duckdb 1.5.2
- [x] Extract pipeline ran successfully (`Pipeline github_issues load step completed`, 0 failed jobs)
- [x] `dbtf build --target dev` — all models built; two pre-existing uniqueness test failures (`unique_stg_issues_issue_number`, `unique_stg_pull_requests_pr_number`) confirmed unrelated to this change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)