### PR TITLE
fix: pin duckdb to 1.5.2 and dbtf to preview.176 for MotherDuck compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: |
           curl -LsSf https://dbc.columnar.tech/install.sh | sh
-          dbc install duckdb
+          dbc install "duckdb=1.5.2"
 
       - name: Compile dbt models
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       # ── dbt compile against prod ─────────────────────────────────────────
       - name: Install dbt Fusion
         run: |
-          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update --version 2.0.0-preview.176
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       # Workaround for dbt-labs/dbt-fusion#1574 — see extract.yml for context.

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -63,6 +63,11 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      - name: Install DuckDB ADBC driver (MotherDuck 1.5.2 pin)
+        run: |
+          curl -LsSf https://dbc.columnar.tech/install.sh | sh
+          dbc install "duckdb=1.5.2"
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dbt Fusion
         run: |
-          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update --version 2.0.0-preview.176
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       # Workaround for dbt-labs/dbt-fusion#1574 — Fusion's bespoke DuckDB ADBC

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install DuckDB ADBC driver (dbt-fusion#1574 workaround)
         run: |
           curl -LsSf https://dbc.columnar.tech/install.sh | sh
-          dbc install duckdb
+          dbc install "duckdb=1.5.2"
 
       - name: Refresh dbt models in MotherDuck
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -47,6 +47,11 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/bruin-data/dac/main/install.sh | bash -s -- -b "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      - name: Install DuckDB ADBC driver (MotherDuck 1.5.2 pin)
+        run: |
+          curl -LsSf https://dbc.columnar.tech/install.sh | sh
+          dbc install "duckdb=1.5.2"
+
       - name: Render About page
         run: uv run python3 dashboard/render_about.py
 

--- a/dashboard/dac/render.py
+++ b/dashboard/dac/render.py
@@ -39,14 +39,17 @@ def warm_bruin_query_runtime(config: Path, env: dict[str, str], env_name: str) -
         "--output",
         "json",
     ]
-    subprocess.run(
+    result = subprocess.run(
         command,
-        check=True,
         env=env,
         cwd=ROOT / "transform",
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
+        capture_output=True,
+        text=True,
     )
+    if result.returncode != 0:
+        print(f"bruin stderr: {result.stderr}", flush=True)
+        print(f"bruin stdout: {result.stdout}", flush=True)
+        raise subprocess.CalledProcessError(result.returncode, command)
 
 
 def extract_static_payload(content: str) -> dict:

--- a/dashboard/dac/render.py
+++ b/dashboard/dac/render.py
@@ -39,17 +39,14 @@ def warm_bruin_query_runtime(config: Path, env: dict[str, str], env_name: str) -
         "--output",
         "json",
     ]
-    result = subprocess.run(
+    subprocess.run(
         command,
+        check=True,
         env=env,
         cwd=ROOT / "transform",
-        capture_output=True,
-        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
     )
-    if result.returncode != 0:
-        print(f"bruin stderr: {result.stderr}", flush=True)
-        print(f"bruin stdout: {result.stdout}", flush=True)
-        raise subprocess.CalledProcessError(result.returncode, command)
 
 
 def extract_static_payload(content: str) -> dict:

--- a/tests/test_dac_dashboard.py
+++ b/tests/test_dac_dashboard.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -46,12 +47,12 @@ class DacDashboardTests(unittest.TestCase):
     def test_dac_project_uses_fusion_issue_marts(self) -> None:
         config = DAC_CONFIG.read_text()
         dashboard = DAC_DASHBOARD.read_text()
+        render = DAC_RENDER.read_text()
 
         self.assertIn("path: ${FUSION_DB}", config)
         self.assertIn("motherduck:", config)
         self.assertIn("token: ${MOTHERDUCK_TOKEN}", config)
         self.assertIn("database: fusion_issues", config)
-        render = DAC_RENDER.read_text()
         self.assertIn('env.setdefault("FUSION_DB", str(ROOT / "data" / "fusion_issues.duckdb"))', render)
         self.assertIn("name: Fusion Issue Analysis", dashboard)
         self.assertIn("connection: fusion", dashboard)
@@ -104,6 +105,30 @@ class DacDashboardTests(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "index.html"
             path.write_text('<script>window.__DAC_STATIC__={"widgetData":{"Open Issues":{"columns":null,"rows":[]}}};</script>')
+
+            with self.assertRaises(SystemExit):
+                module.validate_static_output(path)
+
+    def test_dac_static_output_validation_rejects_widget_errors(self) -> None:
+        spec = importlib.util.spec_from_file_location("render", DAC_RENDER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "index.html"
+            payload = {
+                "widgetData": {
+                    "r0-w0": {
+                        "columns": None,
+                        "rows": None,
+                        "query": "select 1",
+                        "error": "bruin query failed",
+                    }
+                }
+            }
+            path.write_text(f"<script>window.__DAC_STATIC__={json.dumps(payload)};</script>")
 
             with self.assertRaises(SystemExit):
                 module.validate_static_output(path)


### PR DESCRIPTION
## Summary

- Pins `duckdb` to exactly `1.5.2` in `pyproject.toml` (was `>=1.5.2`, which pulled in 1.5.3)
- Pins dbt Fusion CLI to `2.0.0-preview.176` in both CI workflows (`ci.yml`, `extract.yml`)

## Why

duckdb 1.5.3 broke MotherDuck connectivity. Fusion preview.177+ ships its own bundled duckdb 1.5.3, which conflicts with the MotherDuck ADBC driver used in the extract pipeline. Locking both the Python package and the Fusion binary to the last known-good versions unblocks the dashboard and CI until upstream fixes land.

## Test plan

- [ ] CI passes on this branch (dbt build + extract workflow)
- [ ] Dashboard at https://dataders.github.io/fusion_issue_analysis/ loads data after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)