### PR TITLE
feat: extract milestones as a first-class dlt resource

### DIFF
--- a/extract/github/__init__.py
+++ b/extract/github/__init__.py
@@ -7,7 +7,7 @@ import dlt
 from dlt.common.typing import TDataItems
 from dlt.sources import DltResource
 
-from .helpers import get_reactions_data, get_rest_pages, get_stargazers
+from .helpers import get_milestones, get_reactions_data, get_rest_pages, get_stargazers
 
 
 @dlt.source
@@ -59,7 +59,11 @@ def github_reactions(
             since=updated_at.last_value,
         )
 
-    return issues, pull_requests
+    @dlt.resource(primary_key="number", write_disposition="replace")
+    def milestones():
+        yield from get_milestones(owner, name, access_token, items_per_page, max_items)
+
+    return issues, pull_requests, milestones
 
 
 @dlt.source(max_table_nesting=2)

--- a/extract/github/helpers.py
+++ b/extract/github/helpers.py
@@ -9,6 +9,7 @@ from .queries import (
     COMMENT_REACTIONS_QUERY,
     ISSUE_ONLY_FIELDS,
     ISSUES_QUERY,
+    MILESTONES_QUERY,
     STARGAZERS_QUERY,
     RATE_LIMIT,
 )
@@ -72,6 +73,20 @@ def get_stargazers(
             lambda item: {"starredAt": item["starredAt"], "user": item["node"]},
             page_items,
         )
+
+
+def get_milestones(
+    owner: str,
+    name: str,
+    access_token: str,
+    items_per_page: int,
+    max_items: Optional[int],
+) -> Iterator[List[StrAny]]:
+    variables = {"owner": owner, "name": name, "items_per_page": items_per_page}
+    for page_items in _get_graphql_pages(
+        access_token, MILESTONES_QUERY, variables, "milestones", max_items
+    ):
+        yield page_items
 
 
 def get_reactions_data(

--- a/extract/github/queries.py
+++ b/extract/github/queries.py
@@ -136,6 +136,34 @@ node_%s: node(id:"%s") {
   }
 """
 
+MILESTONES_QUERY = """
+query($owner: String!, $name: String!, $items_per_page: Int!, $page_after: String) {
+  repository(owner: $owner, name: $name) {
+    milestones(first: $items_per_page, after: $page_after, states: [OPEN, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+      }
+      nodes {
+        number
+        title
+        description
+        state
+        dueOn
+        createdAt
+        updatedAt
+        closedAt
+      }
+    }
+  }
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
 STARGAZERS_QUERY = """
 query($owner: String!, $name: String!, $items_per_page: Int!, $page_after: String) {
   repository(owner: $owner, name: $name) {

--- a/extract/run.py
+++ b/extract/run.py
@@ -61,7 +61,7 @@ def main():
         # under GitHub's GraphQL resource-limits ceiling.
         items_per_page=50 if args.limit is None else min(50, args.limit),
         max_items=args.limit,
-    ).with_resources("issues", "pull_requests")
+    ).with_resources("issues", "pull_requests", "milestones")
 
     # pull_requests uses replace so child tables never need _dlt_root_id.
     # Drop stuck pending packages so retried merge jobs from prior failed runs

--- a/transform/models/marts/dim_milestones.sql
+++ b/transform/models/marts/dim_milestones.sql
@@ -1,4 +1,27 @@
-select distinct
+-- SELECT DISTINCT on all columns doesn't deduplicate by milestone_number:
+-- a milestone whose state/due_date changes across issues yields multiple rows.
+-- Use a window function to keep one row per milestone (most recent state wins).
+with milestones as (
+    select
+        milestone_number,
+        milestone_title,
+        milestone_description,
+        milestone_state,
+        milestone_due_on,
+        milestone_created_at,
+        milestone_closed_at,
+        row_number() over (
+            partition by milestone_number
+            order by
+                case when milestone_state = 'CLOSED' then 0 else 1 end,
+                milestone_closed_at desc nulls last,
+                milestone_due_on    desc nulls last
+        ) as rn
+    from {{ ref('stg_issues') }}
+    where milestone_number is not null
+)
+
+select
     milestone_number,
     milestone_title,
     milestone_description,
@@ -6,5 +29,5 @@ select distinct
     milestone_due_on,
     milestone_created_at,
     milestone_closed_at
-from {{ ref('stg_issues') }}
-where milestone_number is not null
+from milestones
+where rn = 1

--- a/transform/models/marts/dim_milestones.sql
+++ b/transform/models/marts/dim_milestones.sql
@@ -1,26 +1,3 @@
--- SELECT DISTINCT on all columns doesn't deduplicate by milestone_number:
--- a milestone whose state/due_date changes across issues yields multiple rows.
--- Use a window function to keep one row per milestone (most recent state wins).
-with milestones as (
-    select
-        milestone_number,
-        milestone_title,
-        milestone_description,
-        milestone_state,
-        milestone_due_on,
-        milestone_created_at,
-        milestone_closed_at,
-        row_number() over (
-            partition by milestone_number
-            order by
-                case when milestone_state = 'CLOSED' then 0 else 1 end,
-                milestone_closed_at desc nulls last,
-                milestone_due_on    desc nulls last
-        ) as rn
-    from {{ ref('stg_issues') }}
-    where milestone_number is not null
-)
-
 select
     milestone_number,
     milestone_title,
@@ -29,5 +6,4 @@ select
     milestone_due_on,
     milestone_created_at,
     milestone_closed_at
-from milestones
-where rn = 1
+from {{ ref('stg_milestones') }}

--- a/transform/models/staging/_sources.yml
+++ b/transform/models/staging/_sources.yml
@@ -6,6 +6,8 @@ sources:
       Raw GitHub issue data extracted via dlt from dbt-labs/dbt-fusion.
       Parquet files in data/raw/fusion_issues/. Gitignored — run extract/run.py to populate.
     tables:
+      - name: milestones
+        description: Raw milestones extracted directly from GitHub GraphQL (all states, one row per milestone).
       - name: issues
         description: Raw issues from dlt GraphQL extract (flattened nested fields use double-underscore separators).
         columns:
@@ -18,6 +20,20 @@ sources:
           - name: parent__issue_type__name
             description: Parent issue's native Issue Type
 models:
+  - name: stg_milestones
+    description: One row per milestone from the direct GitHub milestones extract.
+    columns:
+      - name: milestone_number
+        tests:
+          - unique
+          - not_null
+      - name: milestone_state
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['OPEN', 'CLOSED']
+
   - name: stg_issues
     description: Cleaned issues from dbt-labs/dbt-fusion
     columns:

--- a/transform/models/staging/stg_milestones.sql
+++ b/transform/models/staging/stg_milestones.sql
@@ -1,0 +1,10 @@
+select
+    number      as milestone_number,
+    title       as milestone_title,
+    description as milestone_description,
+    state       as milestone_state,
+    due_on      as milestone_due_on,
+    created_at  as milestone_created_at,
+    updated_at  as milestone_updated_at,
+    closed_at   as milestone_closed_at
+from {{ raw_source('milestones') }}


### PR DESCRIPTION
## Summary

- **Root cause:** `dim_milestones` was built from issue-embedded milestone metadata. A milestone that changed state (OPEN → CLOSED) between extractions appeared as two distinct rows for the same `milestone_number`, breaking the `unique_fct_milestones_milestone_number` test.
- **Fix:** Add a `milestones` resource to the dlt pipeline that queries GitHub GraphQL directly for all milestones (both `OPEN` and `CLOSED` states). This is the authoritative, deduplicated source.
- **Transform cleanup:** New `stg_milestones` staging model; `dim_milestones` simplified to a plain `select` from it — no dedup logic needed.

## Changes

| File | Change |
|------|--------|
| `extract/github/queries.py` | Add `MILESTONES_QUERY` |
| `extract/github/helpers.py` | Add `get_milestones` helper |
| `extract/github/__init__.py` | Add `milestones` resource to `github_reactions` source |
| `extract/run.py` | Load milestones alongside issues and pull_requests |
| `transform/models/staging/stg_milestones.sql` | New staging model |
| `transform/models/staging/_sources.yml` | Document source table + model with uniqueness test |
| `transform/models/marts/dim_milestones.sql` | Simplified to `select … from stg_milestones` |

## Test plan
- [ ] Run `cd extract && uv run python run.py --motherduck` — verify `raw_github.milestones` table is populated with all milestones
- [ ] Run `dbtf build --select stg_milestones dim_milestones fct_milestones --profiles-dir . --target prod` — `unique_fct_milestones_milestone_number` passes, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)