### PR TITLE
fix: unquote bucket_sort_order accepted_values test for MotherDuck

### DIFF
--- a/transform/models/dashboard/_schema.yml
+++ b/transform/models/dashboard/_schema.yml
@@ -125,6 +125,7 @@ models:
           - accepted_values:
               arguments:
                 values: [1, 2, 3, 4, 5]
+                quote: false
       - name: issue_count
         tests:
           - not_null


### PR DESCRIPTION
The merge of #81 failed the prod dbt build with `dbt0409: IN failed: Cannot find super type for integer and varchar`: `accepted_values` quotes its list by default, and MotherDuck (unlike local DuckDB) refuses `integer IN ('1','2',...)`. The erroring test blocked `age_distribution_wide` from materializing, which is why the Prefab and DAC framework builds failed in the deploy run (they read the wide table); everything else (215/221) built fine.

One-line fix: `quote: false`. Verified locally — the test now compiles to `value_field not in (1,2,3,4,5)` and `dbtf build --select age_distribution+` passes 11/11.

Merging this re-triggers extract.yml (transform/** path filter), which will materialize `age_distribution_wide` into MotherDuck; I'll re-dispatch deploy-dashboard once it's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)