### PR TITLE
Stabilize scheduled extract workflow

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -12,14 +12,21 @@ on:
       - '.github/workflows/extract.yml'
   workflow_dispatch:
 
+concurrency:
+  group: extract-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   extract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary

Stabilizes the scheduled extract workflow by preventing overlapping runs on the same ref and updates the workflow actions to the repo's current runner baseline.

## Why

GitHub scheduled runs can start late. Without workflow concurrency, a delayed extract run can overlap a newer scheduled, push, or manual run against the same branch. That makes the MotherDuck refresh path noisier than it needs to be.

## Validation

- `uv run python` YAML/assertion check for the extract workflow concurrency and action versions

## Dashboard Preview

🔗 [Preview link](https://dataders.github.io/fusion_issue_analysis/) (auto-posted by CI)
